### PR TITLE
:sparkles: allow setting referrer policy for requests

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/package.json
+++ b/src/Spillgebees.Blazor.Map.Assets/package.json
@@ -29,7 +29,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "maplibre-gl": "5.20.2"
+    "maplibre-gl": "5.21.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",

--- a/src/Spillgebees.Blazor.Map.Assets/pnpm-lock.yaml
+++ b/src/Spillgebees.Blazor.Map.Assets/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       maplibre-gl:
-        specifier: 5.20.2
-        version: 5.20.2
+        specifier: 5.21.1
+        version: 5.21.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.4
@@ -378,8 +378,8 @@ packages:
     resolution: {integrity: sha512-Ed7rcKYU5iELfablg9Mj+TVCsXsPBgdMyXPRAxb2v7oWg9YJnpQdZ5msDs1LESu/mtXy3Z48Vdppv2t/x5kAhw==}
     hasBin: true
 
-  '@maplibre/mlt@1.1.7':
-    resolution: {integrity: sha512-HZSsXrgn2V6T3o0qklMwKERfKaAxjO8shmiFnVygCtXTg4SPKWVX+U99RkvxUfCsjYBEcT4ltor8lSlBSCca7Q==}
+  '@maplibre/mlt@1.1.8':
+    resolution: {integrity: sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==}
 
   '@maplibre/vt-pbf@4.3.0':
     resolution: {integrity: sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==}
@@ -860,8 +860,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  maplibre-gl@5.20.2:
-    resolution: {integrity: sha512-0UzMWOe+GZmIUmOA99yTI1vRh15YcGnHxADVB2s+JF3etpjj2/MBCqbPEuu4BP9mLsJWJcpHH0Nzr9uuimmbuQ==}
+  maplibre-gl@5.21.1:
+    resolution: {integrity: sha512-zto1RTnFkOpOO1bm93ElCXF1huey2N4LvXaGLMFcYAu9txh0OhGIdX1q3LZLkrMKgMxMeYduaQo+DVNzg098fg==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   mdn-data@2.12.2:
@@ -1373,7 +1373,7 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@maplibre/mlt@1.1.7':
+  '@maplibre/mlt@1.1.8':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
 
@@ -1814,7 +1814,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  maplibre-gl@5.20.2:
+  maplibre-gl@5.21.1:
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/point-geometry': 1.1.0
@@ -1824,7 +1824,7 @@ snapshots:
       '@mapbox/whoots-js': 3.1.0
       '@maplibre/geojson-vt': 6.0.4
       '@maplibre/maplibre-gl-style-spec': 24.7.0
-      '@maplibre/mlt': 1.1.7
+      '@maplibre/mlt': 1.1.8
       '@maplibre/vt-pbf': 4.3.0
       '@types/geojson': 7946.0.16
       earcut: 3.0.2

--- a/src/Spillgebees.Blazor.Map.Assets/src/interfaces/map.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/interfaces/map.ts
@@ -36,14 +36,26 @@ export interface IMapBounds {
 export interface IMapStyle {
   id: string | null;
   url: string | null;
+  referrerPolicy?: ReferrerPolicy | null;
   rasterSource: IRasterTileSource | null;
   wmsSource: IWmsTileSource | null;
 }
+
+export type ReferrerPolicy =
+  | "no-referrer"
+  | "no-referrer-when-downgrade"
+  | "origin"
+  | "origin-when-cross-origin"
+  | "same-origin"
+  | "strict-origin"
+  | "strict-origin-when-cross-origin"
+  | "unsafe-url";
 
 export interface IRasterTileSource {
   urlTemplate: string;
   attribution: string;
   tileSize: number;
+  referrerPolicy?: ReferrerPolicy | null;
 }
 
 export interface IWmsTileSource {
@@ -54,6 +66,7 @@ export interface IWmsTileSource {
   transparent: boolean;
   version: string;
   tileSize: number;
+  referrerPolicy?: ReferrerPolicy | null;
 }
 
 export interface ITileOverlay {
@@ -62,6 +75,7 @@ export interface ITileOverlay {
   attribution: string;
   tileSize: number;
   opacity: number;
+  referrerPolicy?: ReferrerPolicy | null;
 }
 
 export interface IFitBoundsOptions {

--- a/src/Spillgebees.Blazor.Map.Assets/src/interfaces/spillgebees.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/interfaces/spillgebees.ts
@@ -2,7 +2,7 @@ import type { DotNet } from "@microsoft/dotnet-js-interop";
 import type { IControl, Map as MapLibreMap, StyleSpecification } from "maplibre-gl";
 import type { FeatureStorage } from "../types/feature-storage";
 import type { ILegendControlOptions, IMapControlOptions } from "./controls";
-import type { IMapOptions } from "./map";
+import type { IMapOptions, ITileOverlay, ReferrerPolicy } from "./map";
 
 export interface RegisteredMapSource {
   sourceId: string;
@@ -55,12 +55,18 @@ export interface ComposedStyleLayerRegistration {
   originalLayerId: string;
 }
 
+export interface OverlayStyleRequestOptions {
+  styleId: string;
+  url: string;
+  referrerPolicy: ReferrerPolicy | null;
+}
+
 export interface SpillgebeesMapNamespace {
   getProtocolVersion: () => number;
   mapFunctions: Record<string, (...args: unknown[]) => unknown>;
   maps: Map<HTMLElement, MapLibreMap>;
   features: Map<MapLibreMap, FeatureStorage>;
-  overlays: Map<MapLibreMap, Map<string, unknown>>;
+  overlays: Map<MapLibreMap, Map<string, ITileOverlay>>;
   controls: Map<MapLibreMap, Set<IControl>>;
   legendControls: Map<MapLibreMap, IControl>;
   legendControlOptions: Map<MapLibreMap, ILegendControlOptions | null>;
@@ -74,6 +80,8 @@ export interface SpillgebeesMapNamespace {
   layerEventSubscriptions: Map<MapLibreMap, Map<string, LayerEventSubscription>>;
   visibilityGroups: Map<MapLibreMap, Map<string, VisibilityGroupRegistration>>;
   overlayStyleUrls: Map<MapLibreMap, string[]>;
+  overlayStyleRequests: Map<MapLibreMap, OverlayStyleRequestOptions[]>;
   composedStyleLayerIds: Map<MapLibreMap, Map<string, ComposedStyleLayerRegistration>>;
   pendingStyleReloads: WeakSet<MapLibreMap>;
+  requestContexts: Map<MapLibreMap, { mapOptions: IMapOptions; overlays: ITileOverlay[] }>;
 }

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
@@ -336,41 +336,6 @@ describe("buildStyleFromOptions", () => {
           tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
           tileSize: 256,
           attribution: "© Example",
-          referrerPolicy: "origin",
-        },
-      },
-      layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
-    });
-  });
-
-  it("should apply style-level referrer policy to raster sources", () => {
-    // arrange
-    const style: IMapStyle = {
-      id: null,
-      url: null,
-      referrerPolicy: "strict-origin-when-cross-origin",
-      rasterSource: {
-        urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
-        attribution: "© Example",
-        tileSize: 256,
-        referrerPolicy: null,
-      },
-      wmsSource: null,
-    };
-
-    // act
-    const result = buildStyleFromOptions(style);
-
-    // assert
-    expect(result).toEqual({
-      version: 8,
-      sources: {
-        "raster-tiles": {
-          type: "raster",
-          tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
-          tileSize: 256,
-          attribution: "© Example",
-          referrerPolicy: "strict-origin-when-cross-origin",
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -411,48 +376,6 @@ describe("buildStyleFromOptions", () => {
           ],
           tileSize: 256,
           attribution: "© WMS Provider",
-          referrerPolicy: "same-origin",
-        },
-      },
-      layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
-    });
-  });
-
-  it("should apply style-level referrer policy to wms sources", () => {
-    // arrange
-    const style: IMapStyle = {
-      id: null,
-      url: null,
-      referrerPolicy: "no-referrer",
-      rasterSource: null,
-      wmsSource: {
-        baseUrl: "https://wms.example.com/wms",
-        layers: "streets",
-        attribution: "© WMS Provider",
-        format: "image/png",
-        transparent: true,
-        version: "1.1.1",
-        tileSize: 256,
-        referrerPolicy: null,
-      },
-    };
-
-    // act
-    const result = buildStyleFromOptions(style);
-
-    // assert
-    expect(result).toEqual({
-      version: 8,
-      sources: {
-        "raster-tiles": {
-          type: "raster",
-          tiles: [
-            // biome-ignore lint/security/noSecrets: WMS URL for testing, not a secret
-            "https://wms.example.com/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=streets&FORMAT=image/png&TRANSPARENT=true&SRS=EPSG:3857&STYLES=&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}",
-          ],
-          tileSize: 256,
-          attribution: "© WMS Provider",
-          referrerPolicy: "no-referrer",
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -542,7 +465,7 @@ describe("createMap", () => {
     );
   });
 
-  it("should configure transformRequest when the base style declares a referrer policy", () => {
+  it("should configure transformRequest for Style resource type when the base style declares a referrer policy", () => {
     // arrange
     const mapElement = document.createElement("div");
     const dotNetHelper = createMockDotNetHelper();
@@ -561,11 +484,11 @@ describe("createMap", () => {
     createMap(dotNetHelper, "OnMapInitialized", mapElement, mapOptions, controlOptions, "light", [], [], [], []);
 
     // assert
-    const requestParameters = getLatestMockMapInstance()?.transformRequest?.("https://example.com/style.json");
-    expect(requestParameters).toEqual({ referrerPolicy: "no-referrer" });
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.("https://example.com/style.json", "Style");
+    expect(requestParameters).toEqual({ url: "https://example.com/style.json", referrerPolicy: "no-referrer" });
   });
 
-  it("should use origin referrer policy for the openstreetmap preset", () => {
+  it("should apply raster source referrer policy for Tile resource type", () => {
     // arrange
     const mapElement = document.createElement("div");
     const dotNetHelper = createMockDotNetHelper();
@@ -598,69 +521,15 @@ describe("createMap", () => {
       [],
     );
 
-    // assert
+    // assert — uses a resolved tile URL, not the template
     const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
-      "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+      "https://tile.openstreetmap.org/5/16/11.png",
+      "Tile",
     );
-    expect(requestParameters).toEqual({ referrerPolicy: "origin" });
+    expect(requestParameters).toEqual({ url: "https://tile.openstreetmap.org/5/16/11.png", referrerPolicy: "origin" });
   });
 
-  it("should leave custom sources unset when no referrer policy is configured", () => {
-    // arrange
-    const mapElement = document.createElement("div");
-    const dotNetHelper = createMockDotNetHelper();
-    const mapOptions = createDefaultMapOptions({
-      style: {
-        id: "base-style",
-        url: "https://example.com/style.json",
-        referrerPolicy: null,
-        rasterSource: null,
-        wmsSource: null,
-      },
-    });
-    const controlOptions = createDefaultControlOptions();
-
-    // act
-    createMap(dotNetHelper, "OnMapInitialized", mapElement, mapOptions, controlOptions, "light", [], [], [], []);
-
-    // assert
-    const requestParameters = getLatestMockMapInstance()?.transformRequest?.("https://example.com/style.json");
-    expect(requestParameters).toBeUndefined();
-  });
-
-  it("should configure transformRequest for overlays when a referrer policy is configured", () => {
-    // arrange
-    const mapElement = document.createElement("div");
-    const dotNetHelper = createMockDotNetHelper();
-    const overlay: ITileOverlay = {
-      id: "overlay-1",
-      urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
-      attribution: "© Example",
-      tileSize: 256,
-      opacity: 1,
-      referrerPolicy: "same-origin",
-    };
-
-    // act
-    createMap(
-      dotNetHelper,
-      "OnMapInitialized",
-      mapElement,
-      createDefaultMapOptions(),
-      createDefaultControlOptions(),
-      "light",
-      [],
-      [],
-      [],
-      [overlay],
-    );
-
-    // assert
-    const requestParameters = getLatestMockMapInstance()?.transformRequest?.(overlay.urlTemplate);
-    expect(requestParameters).toEqual({ referrerPolicy: "same-origin" });
-  });
-
-  it("should prefer style-level referrer policy for raster sources", () => {
+  it("should fall back to style-level referrer policy for Tile resource type when source has none", () => {
     // arrange
     const mapElement = document.createElement("div");
     const dotNetHelper = createMockDotNetHelper();
@@ -695,12 +564,16 @@ describe("createMap", () => {
 
     // assert
     const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
-      "https://tiles.example.com/{z}/{x}/{y}.png",
+      "https://tiles.example.com/5/16/11.png",
+      "Tile",
     );
-    expect(requestParameters).toEqual({ referrerPolicy: "strict-origin" });
+    expect(requestParameters).toEqual({
+      url: "https://tiles.example.com/5/16/11.png",
+      referrerPolicy: "strict-origin",
+    });
   });
 
-  it("should prefer style-level referrer policy for wms sources", () => {
+  it("should apply WMS source referrer policy for Tile resource type", () => {
     // arrange
     const mapElement = document.createElement("div");
     const dotNetHelper = createMockDotNetHelper();
@@ -722,9 +595,6 @@ describe("createMap", () => {
         },
       },
     });
-    const expectedWmsStyle = buildStyleFromOptions(mapOptions.style as IMapStyle) as {
-      sources: { "raster-tiles": { tiles: string[] } };
-    };
 
     // act
     createMap(
@@ -740,11 +610,158 @@ describe("createMap", () => {
       [],
     );
 
-    // assert
+    // assert — uses a resolved WMS tile URL, not the template
     const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
-      expectedWmsStyle.sources["raster-tiles"].tiles[0],
+      // biome-ignore lint/security/noSecrets: WMS URL for testing, not a secret
+      "https://wms.example.com/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=roads&FORMAT=image/png",
+      "Tile",
     );
-    expect(requestParameters).toEqual({ referrerPolicy: "origin-when-cross-origin" });
+    expect(requestParameters).toEqual({
+      // biome-ignore lint/security/noSecrets: WMS URL for testing, not a secret
+      url: "https://wms.example.com/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=roads&FORMAT=image/png",
+      referrerPolicy: "origin-when-cross-origin",
+    });
+  });
+
+  it("should leave requests unset when no referrer policy is configured", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      style: {
+        id: "base-style",
+        url: "https://example.com/style.json",
+        referrerPolicy: null,
+        rasterSource: null,
+        wmsSource: null,
+      },
+    });
+    const controlOptions = createDefaultControlOptions();
+
+    // act
+    createMap(dotNetHelper, "OnMapInitialized", mapElement, mapOptions, controlOptions, "light", [], [], [], []);
+
+    // assert
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.("https://example.com/style.json", "Style");
+    expect(requestParameters).toBeUndefined();
+  });
+
+  it("should configure transformRequest for overlay tiles matched by URL origin", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const overlay: ITileOverlay = {
+      id: "overlay-1",
+      urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
+      attribution: "© Example",
+      tileSize: 256,
+      opacity: 1,
+      referrerPolicy: "same-origin",
+    };
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions(),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [overlay],
+    );
+
+    // assert — uses a resolved tile URL, matched by URL origin
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
+      "https://tiles.example.com/5/16/11.png",
+      "Tile",
+    );
+    expect(requestParameters).toEqual({ url: "https://tiles.example.com/5/16/11.png", referrerPolicy: "same-origin" });
+  });
+
+  it("should match multiple overlays with different referrer policies by URL origin", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const overlay1: ITileOverlay = {
+      id: "overlay-1",
+      urlTemplate: "https://tiles-a.example.com/{z}/{x}/{y}.png",
+      attribution: "© A",
+      tileSize: 256,
+      opacity: 1,
+      referrerPolicy: "origin",
+    };
+    const overlay2: ITileOverlay = {
+      id: "overlay-2",
+      urlTemplate: "https://tiles-b.example.com/{z}/{x}/{y}.png",
+      attribution: "© B",
+      tileSize: 256,
+      opacity: 1,
+      referrerPolicy: "no-referrer",
+    };
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions(),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [overlay1, overlay2],
+    );
+
+    // assert
+    const mockMap = getLatestMockMapInstance()!;
+    expect(mockMap.transformRequest?.("https://tiles-a.example.com/5/16/11.png", "Tile")).toEqual({
+      url: "https://tiles-a.example.com/5/16/11.png",
+      referrerPolicy: "origin",
+    });
+    expect(mockMap.transformRequest?.("https://tiles-b.example.com/5/16/11.png", "Tile")).toEqual({
+      url: "https://tiles-b.example.com/5/16/11.png",
+      referrerPolicy: "no-referrer",
+    });
+  });
+
+  it("should return undefined for unknown URLs", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      style: {
+        id: "base-style",
+        url: "https://example.com/style.json",
+        referrerPolicy: "no-referrer",
+        rasterSource: null,
+        wmsSource: null,
+      },
+    });
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      mapOptions,
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert — unknown resource type should not match
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
+      "https://unknown.example.com/resource",
+      "Unknown",
+    );
+    expect(requestParameters).toBeUndefined();
   });
 
   it("should build raster style from rasterSource", () => {
@@ -2738,7 +2755,7 @@ describe("setOverlays", () => {
     // act
     setOverlays(mapElement, [overlay]);
 
-    // assert
+    // assert — referrerPolicy should NOT be on the source spec (MapLibre ignores it)
     expect(mockMap.addSource).toHaveBeenCalledWith("sgb-overlay-overlay-1", {
       type: "raster",
       tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
@@ -297,6 +297,7 @@ describe("buildStyleFromOptions", () => {
     const style: IMapStyle = {
       id: null,
       url: "https://example.com/style.json",
+      referrerPolicy: null,
       rasterSource: null,
       wmsSource: null,
     };
@@ -313,10 +314,12 @@ describe("buildStyleFromOptions", () => {
     const style: IMapStyle = {
       id: null,
       url: null,
+      referrerPolicy: null,
       rasterSource: {
         urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
         attribution: "© Example",
         tileSize: 256,
+        referrerPolicy: "origin",
       },
       wmsSource: null,
     };
@@ -333,6 +336,41 @@ describe("buildStyleFromOptions", () => {
           tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
           tileSize: 256,
           attribution: "© Example",
+          referrerPolicy: "origin",
+        },
+      },
+      layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
+    });
+  });
+
+  it("should apply style-level referrer policy to raster sources", () => {
+    // arrange
+    const style: IMapStyle = {
+      id: null,
+      url: null,
+      referrerPolicy: "strict-origin-when-cross-origin",
+      rasterSource: {
+        urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
+        attribution: "© Example",
+        tileSize: 256,
+        referrerPolicy: null,
+      },
+      wmsSource: null,
+    };
+
+    // act
+    const result = buildStyleFromOptions(style);
+
+    // assert
+    expect(result).toEqual({
+      version: 8,
+      sources: {
+        "raster-tiles": {
+          type: "raster",
+          tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
+          tileSize: 256,
+          attribution: "© Example",
+          referrerPolicy: "strict-origin-when-cross-origin",
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -344,6 +382,7 @@ describe("buildStyleFromOptions", () => {
     const style: IMapStyle = {
       id: null,
       url: null,
+      referrerPolicy: null,
       rasterSource: null,
       wmsSource: {
         baseUrl: "https://wms.example.com/wms",
@@ -353,6 +392,7 @@ describe("buildStyleFromOptions", () => {
         transparent: true,
         version: "1.1.1",
         tileSize: 256,
+        referrerPolicy: "same-origin",
       },
     };
 
@@ -371,6 +411,48 @@ describe("buildStyleFromOptions", () => {
           ],
           tileSize: 256,
           attribution: "© WMS Provider",
+          referrerPolicy: "same-origin",
+        },
+      },
+      layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
+    });
+  });
+
+  it("should apply style-level referrer policy to wms sources", () => {
+    // arrange
+    const style: IMapStyle = {
+      id: null,
+      url: null,
+      referrerPolicy: "no-referrer",
+      rasterSource: null,
+      wmsSource: {
+        baseUrl: "https://wms.example.com/wms",
+        layers: "streets",
+        attribution: "© WMS Provider",
+        format: "image/png",
+        transparent: true,
+        version: "1.1.1",
+        tileSize: 256,
+        referrerPolicy: null,
+      },
+    };
+
+    // act
+    const result = buildStyleFromOptions(style);
+
+    // assert
+    expect(result).toEqual({
+      version: 8,
+      sources: {
+        "raster-tiles": {
+          type: "raster",
+          tiles: [
+            // biome-ignore lint/security/noSecrets: WMS URL for testing, not a secret
+            "https://wms.example.com/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=streets&FORMAT=image/png&TRANSPARENT=true&SRS=EPSG:3857&STYLES=&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}",
+          ],
+          tileSize: 256,
+          attribution: "© WMS Provider",
+          referrerPolicy: "no-referrer",
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -382,10 +464,12 @@ describe("buildStyleFromOptions", () => {
     const style: IMapStyle = {
       id: null,
       url: "https://example.com/style.json",
+      referrerPolicy: null,
       rasterSource: {
         urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
         attribution: "© Example",
         tileSize: 256,
+        referrerPolicy: null,
       },
       wmsSource: null,
     };
@@ -458,6 +542,211 @@ describe("createMap", () => {
     );
   });
 
+  it("should configure transformRequest when the base style declares a referrer policy", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      style: {
+        id: "base-style",
+        url: "https://example.com/style.json",
+        referrerPolicy: "no-referrer",
+        rasterSource: null,
+        wmsSource: null,
+      },
+    });
+    const controlOptions = createDefaultControlOptions();
+
+    // act
+    createMap(dotNetHelper, "OnMapInitialized", mapElement, mapOptions, controlOptions, "light", [], [], [], []);
+
+    // assert
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.("https://example.com/style.json");
+    expect(requestParameters).toEqual({ referrerPolicy: "no-referrer" });
+  });
+
+  it("should use origin referrer policy for the openstreetmap preset", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      style: {
+        id: "sgb-openstreetmap-standard",
+        url: null,
+        referrerPolicy: null,
+        rasterSource: {
+          urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+          attribution: "© OpenStreetMap contributors",
+          tileSize: 256,
+          referrerPolicy: "origin",
+        },
+        wmsSource: null,
+      },
+    });
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      mapOptions,
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
+      "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+    );
+    expect(requestParameters).toEqual({ referrerPolicy: "origin" });
+  });
+
+  it("should leave custom sources unset when no referrer policy is configured", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      style: {
+        id: "base-style",
+        url: "https://example.com/style.json",
+        referrerPolicy: null,
+        rasterSource: null,
+        wmsSource: null,
+      },
+    });
+    const controlOptions = createDefaultControlOptions();
+
+    // act
+    createMap(dotNetHelper, "OnMapInitialized", mapElement, mapOptions, controlOptions, "light", [], [], [], []);
+
+    // assert
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.("https://example.com/style.json");
+    expect(requestParameters).toBeUndefined();
+  });
+
+  it("should configure transformRequest for overlays when a referrer policy is configured", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const overlay: ITileOverlay = {
+      id: "overlay-1",
+      urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
+      attribution: "© Example",
+      tileSize: 256,
+      opacity: 1,
+      referrerPolicy: "same-origin",
+    };
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions(),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [overlay],
+    );
+
+    // assert
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.(overlay.urlTemplate);
+    expect(requestParameters).toEqual({ referrerPolicy: "same-origin" });
+  });
+
+  it("should prefer style-level referrer policy for raster sources", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      style: {
+        id: "raster-style",
+        url: null,
+        referrerPolicy: "strict-origin",
+        rasterSource: {
+          urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
+          attribution: "© Example",
+          tileSize: 256,
+          referrerPolicy: null,
+        },
+        wmsSource: null,
+      },
+    });
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      mapOptions,
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
+      "https://tiles.example.com/{z}/{x}/{y}.png",
+    );
+    expect(requestParameters).toEqual({ referrerPolicy: "strict-origin" });
+  });
+
+  it("should prefer style-level referrer policy for wms sources", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      style: {
+        id: "wms-style",
+        url: null,
+        referrerPolicy: "origin-when-cross-origin",
+        rasterSource: null,
+        wmsSource: {
+          baseUrl: "https://wms.example.com/wms",
+          layers: "roads",
+          attribution: "© Example",
+          format: "image/png",
+          transparent: true,
+          version: "1.1.1",
+          tileSize: 256,
+          referrerPolicy: null,
+        },
+      },
+    });
+    const expectedWmsStyle = buildStyleFromOptions(mapOptions.style as IMapStyle) as {
+      sources: { "raster-tiles": { tiles: string[] } };
+    };
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      mapOptions,
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    const requestParameters = getLatestMockMapInstance()?.transformRequest?.(
+      expectedWmsStyle.sources["raster-tiles"].tiles[0],
+    );
+    expect(requestParameters).toEqual({ referrerPolicy: "origin-when-cross-origin" });
+  });
+
   it("should build raster style from rasterSource", () => {
     // arrange
     const mapElement = document.createElement("div");
@@ -466,6 +755,7 @@ describe("createMap", () => {
       style: {
         id: null,
         url: null,
+        referrerPolicy: null,
         rasterSource: {
           urlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png",
           attribution: "© Example",
@@ -904,7 +1194,13 @@ describe("setMapOptions", () => {
     mockMap.addLayer.mockClear();
 
     const newOptions = createDefaultMapOptions({
-      style: { id: "sgb-new-style", url: "https://example.com/new-style.json", rasterSource: null, wmsSource: null },
+      style: {
+        id: "sgb-new-style",
+        url: "https://example.com/new-style.json",
+        referrerPolicy: null,
+        rasterSource: null,
+        wmsSource: null,
+      },
     });
 
     // act
@@ -979,7 +1275,13 @@ describe("setMapOptions", () => {
     setMapOptions(
       mapElement,
       createDefaultMapOptions({
-        style: { id: "sgb-new-style", url: "https://example.com/new-style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "sgb-new-style",
+          url: "https://example.com/new-style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
     );
     fireMapEvent("styledata");
@@ -1188,7 +1490,13 @@ describe("setMapOptions", () => {
     setMapOptions(
       mapElement,
       createDefaultMapOptions({
-        style: { id: "sgb-alt-style", url: "https://example.com/alt-style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "sgb-alt-style",
+          url: "https://example.com/alt-style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
     );
     fireMapEvent("styledata");
@@ -1214,10 +1522,17 @@ describe("setMapOptions", () => {
       mapElement,
       createDefaultMapOptions({
         styles: [
-          { id: "sgb-base-style", url: "https://example.com/base-style.json", rasterSource: null, wmsSource: null },
+          {
+            id: "sgb-base-style",
+            url: "https://example.com/base-style.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
           {
             id: "sgb-overlay-style",
             url: "https://example.com/overlay-style.json",
+            referrerPolicy: null,
             rasterSource: null,
             wmsSource: null,
           },
@@ -1241,12 +1556,14 @@ describe("setMapOptions", () => {
           {
             id: "sgb-alt-base-style",
             url: "https://example.com/alt-base-style.json",
+            referrerPolicy: null,
             rasterSource: null,
             wmsSource: null,
           },
           {
             id: "sgb-overlay-style",
             url: "https://example.com/overlay-style.json",
+            referrerPolicy: null,
             rasterSource: null,
             wmsSource: null,
           },
@@ -1258,7 +1575,7 @@ describe("setMapOptions", () => {
     // assert
     expect(applyOverlayStylesSpy).toHaveBeenCalledWith(
       expect.anything(),
-      [{ styleId: "sgb-overlay-style", url: "https://example.com/overlay-style.json" }],
+      [{ styleId: "sgb-overlay-style", url: "https://example.com/overlay-style.json", referrerPolicy: null }],
       {
         forceReapply: true,
       },
@@ -1287,10 +1604,17 @@ describe("setMapOptions", () => {
       mapElement,
       createDefaultMapOptions({
         styles: [
-          { id: "sgb-base-style", url: "https://example.com/base-style.json", rasterSource: null, wmsSource: null },
+          {
+            id: "sgb-base-style",
+            url: "https://example.com/base-style.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
           {
             id: "sgb-overlay-style",
             url: "https://example.com/overlay-style.json",
+            referrerPolicy: null,
             rasterSource: null,
             wmsSource: null,
           },
@@ -1316,12 +1640,14 @@ describe("setMapOptions", () => {
           {
             id: "sgb-alt-base-style",
             url: "https://example.com/alt-base-style.json",
+            referrerPolicy: null,
             rasterSource: null,
             wmsSource: null,
           },
           {
             id: "sgb-overlay-style",
             url: "https://example.com/overlay-style.json",
+            referrerPolicy: null,
             rasterSource: null,
             wmsSource: null,
           },
@@ -1334,7 +1660,7 @@ describe("setMapOptions", () => {
     // assert
     expect(applyOverlayStylesSpy).toHaveBeenCalledWith(
       expect.anything(),
-      [{ styleId: "sgb-overlay-style", url: "https://example.com/overlay-style.json" }],
+      [{ styleId: "sgb-overlay-style", url: "https://example.com/overlay-style.json", referrerPolicy: null }],
       { forceReapply: true },
     );
     // biome-ignore lint/security/noSecrets: C# callback method name under test, not a secret
@@ -1421,7 +1747,13 @@ describe("setMapOptions", () => {
     setMapOptions(
       mapElement,
       createDefaultMapOptions({
-        style: { id: "sgb-base-style", url: "https://example.com/new-style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "sgb-base-style",
+          url: "https://example.com/new-style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
     );
     fireMapEvent("styledata");
@@ -3015,7 +3347,13 @@ describe("advanced interop helpers", () => {
       mapElement,
       createDefaultMapOptions({
         styles: [
-          { id: "sgb-positron", url: "https://example.com/base-style.json", rasterSource: null, wmsSource: null },
+          {
+            id: "sgb-positron",
+            url: "https://example.com/base-style.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
         ],
       }),
       createDefaultControlOptions(),
@@ -3515,7 +3853,13 @@ describe("composed glyph validation", () => {
     const mapElement = document.createElement("div");
     const dotNetHelper = createMockDotNetHelper();
     const mapOptions = createDefaultMapOptions({
-      style: { id: "sgb-base", url: "https://example.com/base.json", rasterSource: null, wmsSource: null },
+      style: {
+        id: "sgb-base",
+        url: "https://example.com/base.json",
+        referrerPolicy: null,
+        rasterSource: null,
+        wmsSource: null,
+      },
     });
 
     // act
@@ -3545,8 +3889,20 @@ describe("composed glyph validation", () => {
     const dotNetHelper = createMockDotNetHelper();
     const mapOptions = createDefaultMapOptions({
       styles: [
-        { id: "sgb-base", url: "https://example.com/base.json", rasterSource: null, wmsSource: null },
-        { id: "sgb-overlay", url: "https://example.com/overlay.json", rasterSource: null, wmsSource: null },
+        {
+          id: "sgb-base",
+          url: "https://example.com/base.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
+        {
+          id: "sgb-overlay",
+          url: "https://example.com/overlay.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       ],
     });
 
@@ -3572,9 +3928,70 @@ describe("composed glyph validation", () => {
     });
 
     // assert
-    expect(validateComposedGlyphsSpy).toHaveBeenCalledWith(map, ["https://example.com/overlay.json"], null);
-    expect(applyOverlayStylesSpy).toHaveBeenCalled();
+    expect(validateComposedGlyphsSpy).toHaveBeenCalledWith(
+      map,
+      [{ styleId: "sgb-overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      null,
+    );
+    expect(applyOverlayStylesSpy).toHaveBeenCalledWith(map, [
+      { styleId: "sgb-overlay", url: "https://example.com/overlay.json", referrerPolicy: null },
+    ]);
     expect(map.setStyle).not.toHaveBeenCalledWith(expect.anything(), { diff: true });
+  });
+
+  it("should preserve per-style referrer policy for composed overlays during map creation", async () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    const mapOptions = createDefaultMapOptions({
+      styles: [
+        {
+          id: "sgb-base",
+          url: "https://example.com/base.json",
+          referrerPolicy: "origin",
+          rasterSource: null,
+          wmsSource: null,
+        },
+        {
+          id: "sgb-overlay",
+          url: "https://example.com/overlay.json",
+          referrerPolicy: "no-referrer",
+          rasterSource: null,
+          wmsSource: null,
+        },
+      ],
+    });
+
+    validateComposedGlyphsSpy.mockResolvedValue({ proceed: true, effectiveGlyphsUrl: null });
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      mapOptions,
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+    const map = getLatestMockMapInstance()!;
+    fireLoadEvent();
+    await vi.waitFor(() => {
+      expect(dotNetHelper.invokeMethodAsync).toHaveBeenCalledWith("OnMapInitialized");
+    });
+
+    // assert
+    expect(validateComposedGlyphsSpy).toHaveBeenCalledWith(
+      map,
+      [{ styleId: "sgb-overlay", url: "https://example.com/overlay.json", referrerPolicy: "no-referrer" }],
+      null,
+    );
+    expect(applyOverlayStylesSpy).toHaveBeenCalledWith(map, [
+      { styleId: "sgb-overlay", url: "https://example.com/overlay.json", referrerPolicy: "no-referrer" },
+    ]);
   });
 
   it("should reject overlays when glyph validation returns proceed false", async () => {
@@ -3583,8 +4000,20 @@ describe("composed glyph validation", () => {
     const dotNetHelper = createMockDotNetHelper();
     const mapOptions = createDefaultMapOptions({
       styles: [
-        { id: "sgb-base", url: "https://example.com/base.json", rasterSource: null, wmsSource: null },
-        { id: "sgb-overlay", url: "https://example.com/overlay.json", rasterSource: null, wmsSource: null },
+        {
+          id: "sgb-base",
+          url: "https://example.com/base.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
+        {
+          id: "sgb-overlay",
+          url: "https://example.com/overlay.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       ],
     });
 
@@ -3622,8 +4051,20 @@ describe("composed glyph validation", () => {
     const mapOptions = createDefaultMapOptions({
       composedGlyphsUrl,
       styles: [
-        { id: "sgb-base", url: "https://example.com/base.json", rasterSource: null, wmsSource: null },
-        { id: "sgb-overlay", url: "https://example.com/overlay.json", rasterSource: null, wmsSource: null },
+        {
+          id: "sgb-base",
+          url: "https://example.com/base.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
+        {
+          id: "sgb-overlay",
+          url: "https://example.com/overlay.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       ],
     });
 
@@ -3661,8 +4102,20 @@ describe("composed glyph validation", () => {
     const mapOptions = createDefaultMapOptions({
       composedGlyphsUrl: "https://fonts.example.com/{fontstack}/{range}.pbf",
       styles: [
-        { id: "sgb-base", url: "https://example.com/base.json", rasterSource: null, wmsSource: null },
-        { id: "sgb-overlay", url: "https://example.com/overlay.json", rasterSource: null, wmsSource: null },
+        {
+          id: "sgb-base",
+          url: "https://example.com/base.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
+        {
+          id: "sgb-overlay",
+          url: "https://example.com/overlay.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       ],
     });
 
@@ -3705,8 +4158,20 @@ describe("composed glyph validation", () => {
       mapElement,
       createDefaultMapOptions({
         styles: [
-          { id: "sgb-base", url: "https://example.com/base.json", rasterSource: null, wmsSource: null },
-          { id: "sgb-overlay", url: "https://example.com/overlay.json", rasterSource: null, wmsSource: null },
+          {
+            id: "sgb-base",
+            url: "https://example.com/base.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
+          {
+            id: "sgb-overlay",
+            url: "https://example.com/overlay.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
         ],
       }),
       createDefaultControlOptions(),
@@ -3733,8 +4198,20 @@ describe("composed glyph validation", () => {
       createDefaultMapOptions({
         composedGlyphsUrl,
         styles: [
-          { id: "sgb-base", url: "https://example.com/base.json", rasterSource: null, wmsSource: null },
-          { id: "sgb-overlay", url: "https://example.com/overlay.json", rasterSource: null, wmsSource: null },
+          {
+            id: "sgb-base",
+            url: "https://example.com/base.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
+          {
+            id: "sgb-overlay",
+            url: "https://example.com/overlay.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
         ],
       }),
     );
@@ -3745,9 +4222,89 @@ describe("composed glyph validation", () => {
     // assert
     expect(validateComposedGlyphsSpy).toHaveBeenCalledWith(
       map,
-      ["https://example.com/overlay.json"],
+      [{ styleId: "sgb-overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
       composedGlyphsUrl,
     );
     expect(map.setStyle).toHaveBeenCalledWith(expect.objectContaining({ glyphs: composedGlyphsUrl }), { diff: true });
+  });
+
+  it("should preserve per-style referrer policy for composed overlays during map option updates", async () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions({
+        styles: [
+          {
+            id: "sgb-base",
+            url: "https://example.com/base.json",
+            referrerPolicy: "origin",
+            rasterSource: null,
+            wmsSource: null,
+          },
+          {
+            id: "sgb-overlay",
+            url: "https://example.com/overlay.json",
+            referrerPolicy: "same-origin",
+            rasterSource: null,
+            wmsSource: null,
+          },
+        ],
+      }),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+    const map = getLatestMockMapInstance()!;
+    fireLoadEvent();
+    await vi.waitFor(() => {
+      expect(dotNetHelper.invokeMethodAsync).toHaveBeenCalledWith("OnMapInitialized");
+    });
+
+    applyOverlayStylesSpy.mockClear();
+    validateComposedGlyphsSpy.mockResolvedValue({ proceed: true, effectiveGlyphsUrl: null });
+
+    // act
+    setMapOptions(
+      mapElement,
+      createDefaultMapOptions({
+        styles: [
+          {
+            id: "sgb-base",
+            url: "https://example.com/base.json",
+            referrerPolicy: "origin",
+            rasterSource: null,
+            wmsSource: null,
+          },
+          {
+            id: "sgb-overlay",
+            url: "https://example.com/overlay.json",
+            referrerPolicy: "same-origin",
+            rasterSource: null,
+            wmsSource: null,
+          },
+        ],
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(applyOverlayStylesSpy).toHaveBeenCalled();
+    });
+
+    // assert
+    expect(validateComposedGlyphsSpy).toHaveBeenCalledWith(
+      map,
+      [{ styleId: "sgb-overlay", url: "https://example.com/overlay.json", referrerPolicy: "same-origin" }],
+      null,
+    );
+    expect(applyOverlayStylesSpy).toHaveBeenCalledWith(map, [
+      { styleId: "sgb-overlay", url: "https://example.com/overlay.json", referrerPolicy: "same-origin" },
+    ]);
   });
 });

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.ts
@@ -1,5 +1,5 @@
 import type { DotNet } from "@microsoft/dotnet-js-interop";
-import type { IControl, StyleSpecification } from "maplibre-gl";
+import type { IControl, RequestParameters, StyleSpecification } from "maplibre-gl";
 import {
   FullscreenControl,
   GeolocateControl,
@@ -27,6 +27,7 @@ import type { ICoordinate, IFitBoundsOptions, IMapOptions, IMapStyle, ITileOverl
 import type {
   ComposedStyleLayerRegistration,
   LayerEventSubscription,
+  OverlayStyleRequestOptions,
   RegisteredMapImage,
   RegisteredMapLayer,
   RegisteredMapSource,
@@ -60,6 +61,87 @@ import type { FeatureStorage } from "./types/feature-storage";
 export const PROTOCOL_VERSION = 9;
 
 const DEFAULT_STYLE_URL = "https://tiles.openfreemap.org/styles/liberty";
+
+function toRequestReferrerPolicy(value: unknown): RequestParameters["referrerPolicy"] | undefined {
+  return typeof value === "string" ? (value as RequestParameters["referrerPolicy"]) : undefined;
+}
+
+function getStyleRequestReferrerPolicy(
+  style: IMapStyle | null,
+  requestUrl: string,
+): RequestParameters["referrerPolicy"] | undefined {
+  if (!style) {
+    return undefined;
+  }
+
+  if (style.url === requestUrl) {
+    return toRequestReferrerPolicy(style.referrerPolicy);
+  }
+
+  if (style.rasterSource?.urlTemplate === requestUrl) {
+    return toRequestReferrerPolicy(style.rasterSource.referrerPolicy ?? style.referrerPolicy);
+  }
+
+  if (style.wmsSource) {
+    const wmsStyle = buildStyleFromOptions(style);
+    if (typeof wmsStyle !== "string") {
+      const rasterSource = wmsStyle.sources["raster-tiles"] as { tiles?: string[] } | undefined;
+      if (rasterSource?.tiles?.includes(requestUrl)) {
+        return toRequestReferrerPolicy(style.wmsSource.referrerPolicy ?? style.referrerPolicy);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function createTransformRequest(
+  mapOptions: IMapOptions,
+  overlays: ITileOverlay[],
+): (url: string, resourceType?: string) => RequestParameters | undefined {
+  return (url: string) => {
+    const stylesList = mapOptions.styles ?? (mapOptions.style ? [mapOptions.style] : [null]);
+    for (const style of stylesList) {
+      const referrerPolicy = getStyleRequestReferrerPolicy(style, url);
+      if (referrerPolicy) {
+        return { referrerPolicy };
+      }
+    }
+
+    const overlay = overlays.find((candidate) => candidate.urlTemplate === url);
+    const overlayReferrerPolicy = toRequestReferrerPolicy(overlay?.referrerPolicy);
+    if (overlayReferrerPolicy) {
+      return { referrerPolicy: overlayReferrerPolicy };
+    }
+
+    return undefined;
+  };
+}
+
+function createMapTransformRequest(
+  getMap: () => MapLibreMap | null,
+): (url: string, resourceType?: string) => RequestParameters | undefined {
+  return (url: string) => {
+    const map = getMap();
+    if (!map) {
+      return undefined;
+    }
+
+    const requestContext = window.Spillgebees.Map.requestContexts.get(map);
+    if (!requestContext) {
+      return undefined;
+    }
+
+    return createTransformRequest(requestContext.mapOptions, requestContext.overlays)(url);
+  };
+}
+
+function updateMapRequestContext(map: MapLibreMap, mapOptions: IMapOptions, overlays: ITileOverlay[]): void {
+  window.Spillgebees.Map.requestContexts.set(map, {
+    mapOptions: structuredClone(mapOptions),
+    overlays: structuredClone(overlays),
+  });
+}
 
 function isNamespaceCompatible(): boolean {
   try {
@@ -130,8 +212,10 @@ function initializeNamespace(): void {
     layerEventSubscriptions: new Map<MapLibreMap, Map<string, LayerEventSubscription>>(),
     visibilityGroups: new Map<MapLibreMap, Map<string, VisibilityGroupRegistration>>(),
     overlayStyleUrls: new Map<MapLibreMap, string[]>(),
+    overlayStyleRequests: new Map<MapLibreMap, OverlayStyleRequestOptions[]>(),
     composedStyleLayerIds: new Map<MapLibreMap, Map<string, ComposedStyleLayerRegistration>>(),
     pendingStyleReloads: new WeakSet<MapLibreMap>(),
+    requestContexts: new Map<MapLibreMap, { mapOptions: IMapOptions; overlays: ITileOverlay[] }>(),
   };
 }
 
@@ -188,13 +272,13 @@ function getResolvedStyleLayerId(map: MapLibreMap, styleId: string, layerId: str
   return registration?.runtimeLayerId ?? null;
 }
 
-function getComposedOverlayStyles(mapOptions: IMapOptions): Array<{ styleId: string; url: string }> {
+function getComposedOverlayStyles(mapOptions: IMapOptions): OverlayStyleRequestOptions[] {
   const stylesList = mapOptions.styles ?? (mapOptions.style ? [mapOptions.style] : [null]);
 
   return stylesList
     .slice(1)
     .filter((style): style is IMapStyle & { id: string; url: string } => style?.id != null && style.url != null)
-    .map((style) => ({ styleId: style.id, url: style.url }));
+    .map((style) => ({ styleId: style.id, url: style.url, referrerPolicy: style.referrerPolicy ?? null }));
 }
 
 function getBaseStyleId(mapOptions: IMapOptions): string | null {
@@ -264,7 +348,7 @@ function registerStyleReloadHandlers(mapElement: HTMLElement, map: MapLibreMap):
       replayImages: () => replayRegisteredImages(mapElement),
       replayComposedOverlays: async () => {
         const mapOptions = window.Spillgebees.Map.mapOptions.get(map);
-        const overlayStyles = mapOptions ? getComposedOverlayStyles(mapOptions) : [];
+        const overlayStyles = window.Spillgebees.Map.overlayStyleRequests.get(map) ?? [];
         if (overlayStyles.length === 0) {
           return;
         }
@@ -279,7 +363,9 @@ function registerStyleReloadHandlers(mapElement: HTMLElement, map: MapLibreMap):
           }
         }
 
-        await applyOverlayStyles(map, overlayStyles, { forceReapply: true });
+        await applyOverlayStyles(map, overlayStyles, {
+          forceReapply: true,
+        });
       },
       onAfterReplay: async () => {
         const dotNetHelper = window.Spillgebees.Map.dotNetHelpers.get(map);
@@ -332,6 +418,7 @@ export function buildStyleFromOptions(style: IMapStyle | null): string | StyleSp
           tiles: [style.rasterSource.urlTemplate],
           tileSize: style.rasterSource.tileSize,
           attribution: style.rasterSource.attribution,
+          referrerPolicy: style.rasterSource.referrerPolicy ?? style.referrerPolicy ?? undefined,
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -365,6 +452,7 @@ export function buildStyleFromOptions(style: IMapStyle | null): string | StyleSp
           tiles: [wmsUrl],
           tileSize: style.wmsSource.tileSize,
           attribution: style.wmsSource.attribution,
+          referrerPolicy: style.wmsSource.referrerPolicy ?? style.referrerPolicy ?? undefined,
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -402,7 +490,9 @@ export function createMap(
   const overlayStyles = getComposedOverlayStyles(mapOptions);
   const overlayStyleUrls = overlayStyles.map((style) => style.url);
 
-  const map = new MapLibreMap({
+  let map: MapLibreMap | null = null;
+  const transformRequest = createMapTransformRequest(() => map);
+  map = new MapLibreMap({
     container: mapElement,
     style: baseStyle,
     center: [mapOptions.center.longitude, mapOptions.center.latitude],
@@ -420,6 +510,7 @@ export function createMap(
     interactive: mapOptions.interactive,
     cooperativeGestures: mapOptions.cooperativeGestures,
     attributionControl: true,
+    transformRequest,
   });
 
   // Store the map instance
@@ -446,6 +537,10 @@ export function createMap(
   window.Spillgebees.Map.controlOptions.set(map, controlOptions);
   window.Spillgebees.Map.legendControlOptions.set(map, null);
   window.Spillgebees.Map.mapOptions.set(map, mapOptions);
+  window.Spillgebees.Map.requestContexts.set(map, {
+    mapOptions: structuredClone(mapOptions),
+    overlays: structuredClone(overlays),
+  });
 
   // Initialize custom style state stores
   window.Spillgebees.Map.sourceSpecs.set(map, new Map());
@@ -454,6 +549,7 @@ export function createMap(
   window.Spillgebees.Map.layerEventSubscriptions.set(map, new Map());
   window.Spillgebees.Map.visibilityGroups.set(map, new Map());
   window.Spillgebees.Map.overlayStyleUrls.set(map, [...overlayStyleUrls]);
+  window.Spillgebees.Map.overlayStyleRequests.set(map, structuredClone(overlayStyles));
   window.Spillgebees.Map.composedStyleLayerIds.set(map, new Map());
 
   // Track the current style for diffing in setMapOptions
@@ -526,7 +622,7 @@ export function createMap(
     // Apply overlay styles (async — fetches style JSONs and merges sources/layers)
     if (overlayStyles.length > 0) {
       (async () => {
-        const glyphResult = await validateComposedGlyphs(map, overlayStyleUrls, mapOptions.composedGlyphsUrl);
+        const glyphResult = await validateComposedGlyphs(map, overlayStyles, mapOptions.composedGlyphsUrl);
 
         if (glyphResult.proceed) {
           if (glyphResult.effectiveGlyphsUrl) {
@@ -568,6 +664,7 @@ export function disposeMap(mapElement: HTMLElement): void {
   // Clean up style storage
   window.Spillgebees.Map.styles.delete(map);
   window.Spillgebees.Map.mapOptions.delete(map);
+  window.Spillgebees.Map.requestContexts.delete(map);
 
   // Clean up custom style state stores
   window.Spillgebees.Map.sourceSpecs.delete(map);
@@ -576,6 +673,7 @@ export function disposeMap(mapElement: HTMLElement): void {
   window.Spillgebees.Map.layerEventSubscriptions.delete(map);
   window.Spillgebees.Map.visibilityGroups.delete(map);
   window.Spillgebees.Map.overlayStyleUrls.delete(map);
+  window.Spillgebees.Map.overlayStyleRequests.delete(map);
   window.Spillgebees.Map.composedStyleLayerIds.delete(map);
 
   // Clean up dotNetHelper storage
@@ -596,6 +694,10 @@ export function setMapOptions(mapElement: HTMLElement, mapOptions: IMapOptions):
   }
 
   window.Spillgebees.Map.mapOptions.set(map, mapOptions);
+  const existingOverlays = Array.from(
+    (window.Spillgebees.Map.overlays.get(map) ?? new Map()).values(),
+  ) as ITileOverlay[];
+  updateMapRequestContext(map, mapOptions, existingOverlays);
 
   // Update pitch and bearing
   map.setPitch(mapOptions.pitch);
@@ -621,6 +723,7 @@ export function setMapOptions(mapElement: HTMLElement, mapOptions: IMapOptions):
   const overlayStyles = getComposedOverlayStyles(mapOptions);
   const overlayStyleUrls = overlayStyles.map((style) => style.url);
   window.Spillgebees.Map.overlayStyleUrls.set(map, [...overlayStyleUrls]);
+  window.Spillgebees.Map.overlayStyleRequests.set(map, structuredClone(overlayStyles));
 
   // Update base style only if it actually changed (setStyle triggers a full tile reload)
   const currentStyle = window.Spillgebees.Map.styles.get(map);
@@ -636,11 +739,7 @@ export function setMapOptions(mapElement: HTMLElement, mapOptions: IMapOptions):
   } else {
     // Base style unchanged — validate glyphs and update overlays
     void (async () => {
-      const glyphResult = await validateComposedGlyphs(
-        map,
-        overlayStyles.map((s) => s.url),
-        mapOptions.composedGlyphsUrl,
-      );
+      const glyphResult = await validateComposedGlyphs(map, overlayStyles, mapOptions.composedGlyphsUrl);
 
       if (!glyphResult.proceed) {
         return;
@@ -751,6 +850,10 @@ export function setOverlays(mapElement: HTMLElement, overlays: ITileOverlay[]): 
   if (!map) return;
 
   const existingOverlays = window.Spillgebees.Map.overlays.get(map) ?? new Map<string, unknown>();
+  const currentMapOptions = window.Spillgebees.Map.mapOptions.get(map);
+  if (currentMapOptions) {
+    updateMapRequestContext(map, currentMapOptions, overlays);
+  }
   const newOverlayIds = new Set(overlays.map((o) => o.id));
 
   // Remove overlays that are no longer in the list
@@ -779,6 +882,7 @@ export function setOverlays(mapElement: HTMLElement, overlays: ITileOverlay[]): 
       tiles: [overlay.urlTemplate],
       tileSize: overlay.tileSize,
       attribution: overlay.attribution,
+      referrerPolicy: overlay.referrerPolicy ?? undefined,
     });
 
     map.addLayer({

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.ts
@@ -66,52 +66,88 @@ function toRequestReferrerPolicy(value: unknown): RequestParameters["referrerPol
   return typeof value === "string" ? (value as RequestParameters["referrerPolicy"]) : undefined;
 }
 
-function getStyleRequestReferrerPolicy(
-  style: IMapStyle | null,
-  requestUrl: string,
-): RequestParameters["referrerPolicy"] | undefined {
+function resolveStyleTileReferrerPolicy(style: IMapStyle | null): RequestParameters["referrerPolicy"] | undefined {
   if (!style) {
     return undefined;
   }
 
-  if (style.url === requestUrl) {
-    return toRequestReferrerPolicy(style.referrerPolicy);
-  }
-
-  if (style.rasterSource?.urlTemplate === requestUrl) {
+  if (style.rasterSource) {
     return toRequestReferrerPolicy(style.rasterSource.referrerPolicy ?? style.referrerPolicy);
   }
 
   if (style.wmsSource) {
-    const wmsStyle = buildStyleFromOptions(style);
-    if (typeof wmsStyle !== "string") {
-      const rasterSource = wmsStyle.sources["raster-tiles"] as { tiles?: string[] } | undefined;
-      if (rasterSource?.tiles?.includes(requestUrl)) {
-        return toRequestReferrerPolicy(style.wmsSource.referrerPolicy ?? style.referrerPolicy);
+    return toRequestReferrerPolicy(style.wmsSource.referrerPolicy ?? style.referrerPolicy);
+  }
+
+  return toRequestReferrerPolicy(style.referrerPolicy);
+}
+
+function resolveStyleReferrerPolicy(style: IMapStyle | null): RequestParameters["referrerPolicy"] | undefined {
+  if (!style) {
+    return undefined;
+  }
+
+  return toRequestReferrerPolicy(style.referrerPolicy);
+}
+
+function buildOverlayOriginMap(overlays: ITileOverlay[]): Map<string, RequestParameters["referrerPolicy"]> {
+  const originMap = new Map<string, RequestParameters["referrerPolicy"]>();
+
+  for (const overlay of overlays) {
+    const policy = toRequestReferrerPolicy(overlay.referrerPolicy);
+    if (policy) {
+      try {
+        const origin = new URL(overlay.urlTemplate).origin;
+        originMap.set(origin, policy);
+      } catch {
+        // invalid URL template, skip
       }
     }
   }
 
-  return undefined;
+  return originMap;
 }
 
 function createTransformRequest(
   mapOptions: IMapOptions,
   overlays: ITileOverlay[],
 ): (url: string, resourceType?: string) => RequestParameters | undefined {
-  return (url: string) => {
+  const overlayOrigins = buildOverlayOriginMap(overlays);
+
+  return (url: string, resourceType?: string) => {
     const stylesList = mapOptions.styles ?? (mapOptions.style ? [mapOptions.style] : [null]);
-    for (const style of stylesList) {
-      const referrerPolicy = getStyleRequestReferrerPolicy(style, url);
-      if (referrerPolicy) {
-        return { referrerPolicy };
+
+    if (resourceType === "Style") {
+      for (const style of stylesList) {
+        const referrerPolicy = resolveStyleReferrerPolicy(style);
+        if (referrerPolicy) {
+          return { url, referrerPolicy };
+        }
       }
+      return undefined;
     }
 
-    const overlay = overlays.find((candidate) => candidate.urlTemplate === url);
-    const overlayReferrerPolicy = toRequestReferrerPolicy(overlay?.referrerPolicy);
-    if (overlayReferrerPolicy) {
-      return { referrerPolicy: overlayReferrerPolicy };
+    if (resourceType === "Tile" || resourceType === "Source") {
+      // check style-level tile referrer policies first
+      for (const style of stylesList) {
+        const referrerPolicy = resolveStyleTileReferrerPolicy(style);
+        if (referrerPolicy) {
+          return { url, referrerPolicy };
+        }
+      }
+
+      // fall back to overlay origin matching
+      try {
+        const requestOrigin = new URL(url).origin;
+        const overlayPolicy = overlayOrigins.get(requestOrigin);
+        if (overlayPolicy) {
+          return { url, referrerPolicy: overlayPolicy };
+        }
+      } catch {
+        // invalid URL, skip
+      }
+
+      return undefined;
     }
 
     return undefined;
@@ -121,7 +157,7 @@ function createTransformRequest(
 function createMapTransformRequest(
   getMap: () => MapLibreMap | null,
 ): (url: string, resourceType?: string) => RequestParameters | undefined {
-  return (url: string) => {
+  return (url: string, resourceType?: string) => {
     const map = getMap();
     if (!map) {
       return undefined;
@@ -132,7 +168,7 @@ function createMapTransformRequest(
       return undefined;
     }
 
-    return createTransformRequest(requestContext.mapOptions, requestContext.overlays)(url);
+    return createTransformRequest(requestContext.mapOptions, requestContext.overlays)(url, resourceType);
   };
 }
 
@@ -418,7 +454,6 @@ export function buildStyleFromOptions(style: IMapStyle | null): string | StyleSp
           tiles: [style.rasterSource.urlTemplate],
           tileSize: style.rasterSource.tileSize,
           attribution: style.rasterSource.attribution,
-          referrerPolicy: style.rasterSource.referrerPolicy ?? style.referrerPolicy ?? undefined,
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -452,7 +487,6 @@ export function buildStyleFromOptions(style: IMapStyle | null): string | StyleSp
           tiles: [wmsUrl],
           tileSize: style.wmsSource.tileSize,
           attribution: style.wmsSource.attribution,
-          referrerPolicy: style.wmsSource.referrerPolicy ?? style.referrerPolicy ?? undefined,
         },
       },
       layers: [{ id: "raster-layer", type: "raster", source: "raster-tiles" }],
@@ -882,7 +916,6 @@ export function setOverlays(mapElement: HTMLElement, overlays: ITileOverlay[]): 
       tiles: [overlay.urlTemplate],
       tileSize: overlay.tileSize,
       attribution: overlay.attribution,
-      referrerPolicy: overlay.referrerPolicy ?? undefined,
     });
 
     map.addLayer({

--- a/src/Spillgebees.Blazor.Map.Assets/src/runtime/sceneMutations.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/runtime/sceneMutations.test.ts
@@ -57,7 +57,13 @@ describe.sequential("applySceneMutations", () => {
       "OnMapInitialized",
       mapElement,
       createDefaultMapOptions({
-        style: { id: "base-style", url: "https://example.com/style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "base-style",
+          url: "https://example.com/style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
       createDefaultControlOptions(),
       "light",
@@ -152,7 +158,13 @@ describe.sequential("applySceneMutations", () => {
       "OnMapInitialized",
       mapElement,
       createDefaultMapOptions({
-        style: { id: "base-style", url: "https://example.com/style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "base-style",
+          url: "https://example.com/style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
       createDefaultControlOptions(),
       "light",
@@ -226,7 +238,13 @@ describe.sequential("applySceneMutations", () => {
       "OnMapInitialized",
       mapElement,
       createDefaultMapOptions({
-        style: { id: "base-style", url: "https://example.com/style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "base-style",
+          url: "https://example.com/style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
       createDefaultControlOptions(),
       "light",
@@ -342,7 +360,13 @@ describe.sequential("applySceneMutations", () => {
       "OnMapInitialized",
       mapElement,
       createDefaultMapOptions({
-        style: { id: "base-style", url: "https://example.com/style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "base-style",
+          url: "https://example.com/style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
       createDefaultControlOptions(),
       "light",
@@ -445,7 +469,13 @@ describe.sequential("applySceneMutations", () => {
       "OnMapInitialized",
       mapElement,
       createDefaultMapOptions({
-        style: { id: "base-style", url: "https://example.com/style.json", rasterSource: null, wmsSource: null },
+        style: {
+          id: "base-style",
+          url: "https://example.com/style.json",
+          referrerPolicy: null,
+          rasterSource: null,
+          wmsSource: null,
+        },
       }),
       createDefaultControlOptions(),
       "light",
@@ -550,8 +580,20 @@ describe.sequential("applySceneMutations", () => {
       mapElement,
       createDefaultMapOptions({
         styles: [
-          { id: "base-style", url: "https://example.com/base-style.json", rasterSource: null, wmsSource: null },
-          { id: "overlay-style", url: "https://example.com/overlay-style.json", rasterSource: null, wmsSource: null },
+          {
+            id: "base-style",
+            url: "https://example.com/base-style.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
+          {
+            id: "overlay-style",
+            url: "https://example.com/overlay-style.json",
+            referrerPolicy: null,
+            rasterSource: null,
+            wmsSource: null,
+          },
         ],
       }),
       createDefaultControlOptions(),

--- a/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { validateComposedGlyphs } from "./composition";
+import { applyOverlayStyles, validateComposedGlyphs } from "./composition";
 
 function createMockMap(glyphs?: string) {
   return {
@@ -31,7 +31,11 @@ describe("validateComposedGlyphs", () => {
     const map = createMockMap(baseGlyphs);
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/overlay.json"], composedGlyphsUrl);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      composedGlyphsUrl,
+    );
 
     // assert
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: composedGlyphsUrl });
@@ -43,7 +47,11 @@ describe("validateComposedGlyphs", () => {
     const map = createMockMap(sharedGlyphs);
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/overlay.json"], sharedGlyphs);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      sharedGlyphs,
+    );
 
     // assert
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
@@ -67,7 +75,11 @@ describe("validateComposedGlyphs", () => {
     );
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/overlay.json"], null);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      null,
+    );
 
     // assert
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
@@ -93,7 +105,11 @@ describe("validateComposedGlyphs", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/overlay.json"], null);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      null,
+    );
 
     // assert
     expect(result).toEqual({ proceed: false });
@@ -122,7 +138,11 @@ describe("validateComposedGlyphs", () => {
     );
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/styles/overlay.json"], null);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/styles/overlay.json", referrerPolicy: null }],
+      null,
+    );
 
     // assert — ../fonts/ relative to /styles/overlay.json resolves to /fonts/
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
@@ -135,7 +155,11 @@ describe("validateComposedGlyphs", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/overlay.json"], null);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      null,
+    );
 
     // assert — only base glyph URL in set (1 unique), so proceed
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
@@ -148,7 +172,11 @@ describe("validateComposedGlyphs", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network failure")));
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/overlay.json"], null);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      null,
+    );
 
     // assert — only base glyph URL in set (1 unique), so proceed
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
@@ -170,7 +198,11 @@ describe("validateComposedGlyphs", () => {
     );
 
     // act
-    const result = await validateComposedGlyphs(map, ["https://example.com/overlay.json"], null);
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: null }],
+      null,
+    );
 
     // assert — no glyph URLs at all, so proceed
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
@@ -202,12 +234,108 @@ describe("validateComposedGlyphs", () => {
     // act
     const result = await validateComposedGlyphs(
       map,
-      ["https://example.com/overlay-a.json", "https://example.com/overlay-b.json"],
+      [
+        { styleId: "overlay-a", url: "https://example.com/overlay-a.json", referrerPolicy: null },
+        { styleId: "overlay-b", url: "https://example.com/overlay-b.json", referrerPolicy: null },
+      ],
       null,
     );
 
     // assert — two different overlay glyph URLs, no base
     expect(result).toEqual({ proceed: false });
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("should pass referrerPolicy to overlay style fetches when configured", async () => {
+    // arrange
+    const map = createMockMap("https://fonts.example.com/{fontstack}/{range}.pbf");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        version: 8,
+        sources: {},
+        layers: [],
+        glyphs: "https://fonts.example.com/{fontstack}/{range}.pbf",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // act
+    await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: "https://example.com/overlay.json", referrerPolicy: "origin" }],
+      null,
+    );
+
+    // assert
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/overlay.json", { referrerPolicy: "origin" });
+  });
+
+  it("should preserve per-style referrer policies across multiple overlay fetches", async () => {
+    // arrange
+    const map = createMockMap("https://fonts.example.com/{fontstack}/{range}.pbf");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        version: 8,
+        sources: {},
+        layers: [],
+        glyphs: "https://fonts.example.com/{fontstack}/{range}.pbf",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // act
+    await validateComposedGlyphs(
+      map,
+      [
+        { styleId: "overlay-a", url: "https://example.com/a.json", referrerPolicy: "origin" },
+        { styleId: "overlay-b", url: "https://example.com/b.json", referrerPolicy: "no-referrer" },
+      ],
+      null,
+    );
+
+    // assert
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "https://example.com/a.json", { referrerPolicy: "origin" });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "https://example.com/b.json", { referrerPolicy: "no-referrer" });
+  });
+});
+
+describe("applyOverlayStyles", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.Spillgebees = {
+      Map: {
+        composedStyleLayerIds: new Map(),
+      },
+    } as never;
+  });
+
+  it("should fetch each overlay style using its own referrer policy", async () => {
+    // arrange
+    const map = {
+      getSource: vi.fn().mockReturnValue(undefined),
+      addSource: vi.fn(),
+      hasImage: vi.fn().mockReturnValue(true),
+      getLayer: vi.fn().mockReturnValue(undefined),
+      addLayer: vi.fn(),
+    } as unknown as Parameters<typeof applyOverlayStyles>[0];
+    window.Spillgebees.Map.composedStyleLayerIds.set(map, new Map());
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ version: 8, sources: {}, layers: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ version: 8, sources: {}, layers: [] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // act
+    await applyOverlayStyles(map, [
+      { styleId: "a", url: "https://example.com/a.json", referrerPolicy: "origin" },
+      { styleId: "b", url: "https://example.com/b.json", referrerPolicy: "no-referrer" },
+    ]);
+
+    // assert
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "https://example.com/a.json", { referrerPolicy: "origin" });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "https://example.com/b.json", { referrerPolicy: "no-referrer" });
   });
 });

--- a/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.test.ts
@@ -65,6 +65,7 @@ describe("validateComposedGlyphs", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        url: "https://example.com/overlay.json",
         json: vi.fn().mockResolvedValue({
           version: 8,
           sources: {},
@@ -94,6 +95,7 @@ describe("validateComposedGlyphs", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        url: "https://example.com/overlay.json",
         json: vi.fn().mockResolvedValue({
           version: 8,
           sources: {},
@@ -128,6 +130,7 @@ describe("validateComposedGlyphs", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        url: "https://example.com/styles/overlay.json",
         json: vi.fn().mockResolvedValue({
           version: 8,
           sources: {},
@@ -145,6 +148,38 @@ describe("validateComposedGlyphs", () => {
     );
 
     // assert — ../fonts/ relative to /styles/overlay.json resolves to /fonts/
+    expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
+  });
+
+  it("should resolve relative glyph URLs against the final redirect URL, not the original request URL", async () => {
+    // arrange
+    const baseGlyphs = "https://cdn.example.com/v2/fonts/{fontstack}/{range}.pbf";
+    const map = createMockMap(baseGlyphs);
+    const originalUrl = "https://example.com/style.json";
+    const redirectedUrl = "https://cdn.example.com/v2/style.json";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        url: redirectedUrl,
+        json: vi.fn().mockResolvedValue({
+          version: 8,
+          sources: {},
+          layers: [],
+          glyphs: "./fonts/{fontstack}/{range}.pbf",
+        }),
+      }),
+    );
+
+    // act
+    const result = await validateComposedGlyphs(
+      map,
+      [{ styleId: "overlay", url: originalUrl, referrerPolicy: null }],
+      null,
+    );
+
+    // assert — ./fonts/ relative to redirectedUrl resolves to https://cdn.example.com/v2/fonts/...
+    // if resolved against originalUrl it would be https://example.com/fonts/... which differs from baseGlyphs
     expect(result).toEqual({ proceed: true, effectiveGlyphsUrl: null });
   });
 
@@ -189,6 +224,7 @@ describe("validateComposedGlyphs", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        url: "https://example.com/overlay.json",
         json: vi.fn().mockResolvedValue({
           version: 8,
           sources: {},
@@ -217,12 +253,14 @@ describe("validateComposedGlyphs", () => {
         if (url === "https://example.com/overlay-a.json") {
           return Promise.resolve({
             ok: true,
+            url: "https://example.com/overlay-a.json",
             json: () => Promise.resolve({ glyphs: "https://fonts-a.example.com/glyphs" }),
           });
         }
         if (url === "https://example.com/overlay-b.json") {
           return Promise.resolve({
             ok: true,
+            url: "https://example.com/overlay-b.json",
             json: () => Promise.resolve({ glyphs: "https://fonts-b.example.com/glyphs" }),
           });
         }
@@ -251,6 +289,7 @@ describe("validateComposedGlyphs", () => {
     const map = createMockMap("https://fonts.example.com/{fontstack}/{range}.pbf");
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
+      url: "https://example.com/overlay.json",
       json: vi.fn().mockResolvedValue({
         version: 8,
         sources: {},
@@ -276,6 +315,7 @@ describe("validateComposedGlyphs", () => {
     const map = createMockMap("https://fonts.example.com/{fontstack}/{range}.pbf");
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
+      url: "https://example.com/a.json",
       json: vi.fn().mockResolvedValue({
         version: 8,
         sources: {},
@@ -312,6 +352,49 @@ describe("applyOverlayStyles", () => {
     } as never;
   });
 
+  it("should resolve relative source URLs against the final redirect URL, not the original request URL", async () => {
+    // arrange
+    const originalUrl = "https://example.com/style.json";
+    const redirectedUrl = "https://cdn.example.com/v2/style.json";
+    const map = {
+      getSource: vi.fn().mockReturnValue(undefined),
+      addSource: vi.fn(),
+      hasImage: vi.fn().mockReturnValue(true),
+      getLayer: vi.fn().mockReturnValue(undefined),
+      addLayer: vi.fn(),
+    } as unknown as Parameters<typeof applyOverlayStyles>[0];
+    window.Spillgebees.Map.composedStyleLayerIds.set(map, new Map());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        url: redirectedUrl,
+        json: vi.fn().mockResolvedValue({
+          version: 8,
+          sources: {
+            "my-source": {
+              type: "vector",
+              url: "./tiles.json",
+            },
+          },
+          layers: [],
+        }),
+      }),
+    );
+
+    // act
+    await applyOverlayStyles(map, [{ styleId: "overlay", url: originalUrl, referrerPolicy: null }]);
+
+    // assert — ./tiles.json relative to redirectedUrl should resolve to https://cdn.example.com/v2/tiles.json
+    // if resolved against originalUrl, it would be https://example.com/tiles.json (wrong)
+    expect(map.addSource).toHaveBeenCalledWith(
+      "sgb-overlay-style-overlay-my-source",
+      expect.objectContaining({
+        url: "https://cdn.example.com/v2/tiles.json",
+      }),
+    );
+  });
+
   it("should fetch each overlay style using its own referrer policy", async () => {
     // arrange
     const map = {
@@ -324,8 +407,16 @@ describe("applyOverlayStyles", () => {
     window.Spillgebees.Map.composedStyleLayerIds.set(map, new Map());
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ version: 8, sources: {}, layers: [] }) })
-      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ version: 8, sources: {}, layers: [] }) });
+      .mockResolvedValueOnce({
+        ok: true,
+        url: "https://example.com/a.json",
+        json: vi.fn().mockResolvedValue({ version: 8, sources: {}, layers: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        url: "https://example.com/b.json",
+        json: vi.fn().mockResolvedValue({ version: 8, sources: {}, layers: [] }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     // act

--- a/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.ts
@@ -1,4 +1,6 @@
 import type { Map as MapLibreMap, StyleSpecification } from "maplibre-gl";
+import type { ReferrerPolicy } from "../interfaces/map";
+import type { OverlayStyleRequestOptions } from "../interfaces/spillgebees";
 
 /**
  * Prefix used for all overlay-managed sources and layers to avoid ID collisions
@@ -60,6 +62,14 @@ export interface ApplyOverlayStyleOptions {
   forceReapply?: boolean;
 }
 
+function createFetchOptions(referrerPolicy: ReferrerPolicy | null | undefined): RequestInit | undefined {
+  return referrerPolicy ? { referrerPolicy } : undefined;
+}
+
+export function fetchStyleJson(url: string, referrerPolicy: ReferrerPolicy | null): Promise<Response> {
+  return fetch(url, createFetchOptions(referrerPolicy));
+}
+
 // WeakMap so entries are GC'd when the map instance is collected
 const appliedOverlays = new WeakMap<MapLibreMap, Map<string, OverlayStyleState>>();
 
@@ -78,7 +88,7 @@ function getOverlayMap(map: MapLibreMap): Map<string, OverlayStyleState> {
  */
 export async function applyOverlayStyles(
   map: MapLibreMap,
-  overlayStyles: Array<{ styleId: string; url: string }>,
+  overlayStyles: OverlayStyleRequestOptions[],
   options?: ApplyOverlayStyleOptions,
 ): Promise<void> {
   const overlays = getOverlayMap(map);
@@ -116,7 +126,7 @@ export async function applyOverlayStyles(
     }
 
     try {
-      const response = await fetch(url);
+      const response = await fetchStyleJson(url, overlayStyles[i].referrerPolicy);
       if (!response.ok) {
         // biome-ignore lint/suspicious/noConsole: library warning for developers
         console.warn(`[Spillgebees.Map] Failed to fetch overlay style: ${url} (${String(response.status)})`);
@@ -124,7 +134,14 @@ export async function applyOverlayStyles(
       }
 
       const styleJson = (await response.json()) as StyleSpecification;
-      const state = await mergeStyleIntoMap(map, styleJson, `${OVERLAY_PREFIX}-${styleId}`, styleId, url);
+      const state = await mergeStyleIntoMap(
+        map,
+        styleJson,
+        `${OVERLAY_PREFIX}-${styleId}`,
+        styleId,
+        url,
+        overlayStyles[i].referrerPolicy,
+      );
       overlays.set(styleId, state);
       registerComposedLayerIds(composedStyleLayerIds, state);
     } catch (error) {
@@ -152,14 +169,18 @@ function registerComposedLayerIds(
  * Sprite format: {spriteUrl}.json contains image metadata, {spriteUrl}.png is the spritesheet.
  * For retina: {spriteUrl}@2x.json and {spriteUrl}@2x.png.
  */
-async function loadSpriteImages(map: MapLibreMap, spriteUrl: string): Promise<string[]> {
+async function loadSpriteImages(
+  map: MapLibreMap,
+  spriteUrl: string,
+  referrerPolicy: ReferrerPolicy | null,
+): Promise<string[]> {
   const imageIds: string[] = [];
   const pixelRatio = window.devicePixelRatio >= 2 ? 2 : 1;
   const suffix = pixelRatio === 2 ? "@2x" : "";
 
   try {
     // Fetch sprite metadata
-    const metaResponse = await fetch(`${spriteUrl}${suffix}.json`);
+    const metaResponse = await fetch(`${spriteUrl}${suffix}.json`, createFetchOptions(referrerPolicy));
     if (!metaResponse.ok) {
       return imageIds;
     }
@@ -169,7 +190,7 @@ async function loadSpriteImages(map: MapLibreMap, spriteUrl: string): Promise<st
     >;
 
     // Fetch spritesheet image
-    const imageResponse = await fetch(`${spriteUrl}${suffix}.png`);
+    const imageResponse = await fetch(`${spriteUrl}${suffix}.png`, createFetchOptions(referrerPolicy));
     if (!imageResponse.ok) {
       return imageIds;
     }
@@ -219,6 +240,7 @@ async function mergeStyleIntoMap(
   prefix: string,
   styleId: string,
   styleUrl: string,
+  referrerPolicy: ReferrerPolicy | null,
 ): Promise<OverlayStyleState> {
   const sourceIds: string[] = [];
   const layerIds: string[] = [];
@@ -257,7 +279,7 @@ async function mergeStyleIntoMap(
     const rawSpriteUrl = typeof style.sprite === "string" ? style.sprite : undefined;
     if (rawSpriteUrl) {
       const resolvedSpriteUrl = resolveUrl(rawSpriteUrl, styleUrl);
-      imageIds = await loadSpriteImages(map, resolvedSpriteUrl);
+      imageIds = await loadSpriteImages(map, resolvedSpriteUrl, referrerPolicy);
     }
   }
 
@@ -312,10 +334,10 @@ async function mergeStyleIntoMap(
  */
 export async function validateComposedGlyphs(
   map: MapLibreMap,
-  overlayStyleUrls: string[],
+  overlayStyles: OverlayStyleRequestOptions[],
   composedGlyphsUrl: string | null,
 ): Promise<{ proceed: true; effectiveGlyphsUrl: string | null } | { proceed: false }> {
-  if (overlayStyleUrls.length === 0) {
+  if (overlayStyles.length === 0) {
     return { proceed: true, effectiveGlyphsUrl: null };
   }
 
@@ -334,16 +356,16 @@ export async function validateComposedGlyphs(
     glyphUrls.add(baseGlyphs);
   }
 
-  for (const styleUrl of overlayStyleUrls) {
+  for (const overlayStyle of overlayStyles) {
     try {
-      const response = await fetch(styleUrl);
+      const response = await fetchStyleJson(overlayStyle.url, overlayStyle.referrerPolicy);
       if (!response.ok) {
         continue;
       }
 
       const styleJson = (await response.json()) as { glyphs?: string };
       if (styleJson.glyphs) {
-        const resolved = resolveTemplateUrl(styleJson.glyphs, styleUrl);
+        const resolved = resolveTemplateUrl(styleJson.glyphs, overlayStyle.url);
         glyphUrls.add(resolved);
       }
     } catch {

--- a/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.ts
@@ -139,7 +139,7 @@ export async function applyOverlayStyles(
         styleJson,
         `${OVERLAY_PREFIX}-${styleId}`,
         styleId,
-        url,
+        response.url,
         overlayStyles[i].referrerPolicy,
       );
       overlays.set(styleId, state);
@@ -365,7 +365,7 @@ export async function validateComposedGlyphs(
 
       const styleJson = (await response.json()) as { glyphs?: string };
       if (styleJson.glyphs) {
-        const resolved = resolveTemplateUrl(styleJson.glyphs, overlayStyle.url);
+        const resolved = resolveTemplateUrl(styleJson.glyphs, response.url);
         glyphUrls.add(resolved);
       }
     } catch {

--- a/src/Spillgebees.Blazor.Map.Assets/test/maplibreMock.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/test/maplibreMock.ts
@@ -41,6 +41,7 @@ export interface MockMapInstance {
   queryRenderedFeatures: ReturnType<typeof vi.fn>;
   moveLayer: ReturnType<typeof vi.fn>;
   setFeatureState: ReturnType<typeof vi.fn>;
+  transformRequest?: (url: string, resourceType?: string) => unknown;
 }
 
 export interface MockMarkerInstance {
@@ -120,7 +121,10 @@ export function fireLoadEvent(): void {
 }
 
 // Must use function declaration (not arrow) so it can be called with `new`
-const MockMapConstructor = vi.fn().mockImplementation(function (this: MockMapInstance) {
+const MockMapConstructor = vi.fn().mockImplementation(function (
+  this: MockMapInstance,
+  options?: { transformRequest?: (url: string, resourceType?: string) => unknown },
+) {
   this.on = vi.fn().mockImplementation((...args: unknown[]) => {
     const event = args[0] as string;
     // MapLibre supports both map.on(event, callback) and map.on(event, layerId, callback)
@@ -191,6 +195,7 @@ const MockMapConstructor = vi.fn().mockImplementation(function (this: MockMapIns
   this.queryRenderedFeatures = vi.fn().mockReturnValue([]);
   this.moveLayer = vi.fn();
   this.setFeatureState = vi.fn();
+  this.transformRequest = options?.transformRequest;
   latestMockMapInstance = this;
 });
 

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/BasicMapExample.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/BasicMapExample.razor
@@ -7,6 +7,7 @@
 
 @code {
     private readonly MapOptions _mapOptions = new(
+        Style: MapStyle.OpenStreetMap.Standard,
         Center: new Coordinate(49.75, 6.10),
         Zoom: 9,
         FitBoundsOptions: new FitBoundsOptions(

--- a/src/Spillgebees.Blazor.Map.Tests/Interop/MapJsInteropPayloadTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Interop/MapJsInteropPayloadTests.cs
@@ -94,11 +94,49 @@ public class MapJsInteropPayloadTests : BunitContext
         var stylesPayload = GetRequiredPropertyValue(mapOptionsPayload!, "Styles");
         var webFontsPayload = GetRequiredPropertyValue(mapOptionsPayload!, "WebFonts");
 
-        stylesPayload.Should().BeOfType<MapStyle[]>();
-        ((MapStyle[])stylesPayload).Should().Equal(styles);
+        stylesPayload.Should().BeOfType<object[]>();
+        ((object[])stylesPayload).Should().HaveCount(styles.Count);
 
         webFontsPayload.Should().BeOfType<string[]>();
         ((string[])webFontsPayload).Should().Equal(webFonts);
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_send_referrer_policies_when_initializing_map(CancellationToken cancellationToken)
+    {
+        // arrange & act
+        Render<SgbMap>(parameters =>
+            parameters
+                .Add(
+                    p => p.MapOptions,
+                    new MapOptions(
+                        new Coordinate(49.61, 6.13),
+                        Style: MapStyle
+                            .FromUrl("https://example.com/style.json")
+                            .WithReferrerPolicy(ReferrerPolicy.NoReferrer)
+                    )
+                )
+                .Add(
+                    p => p.Overlays,
+                    [
+                        new TileOverlay(
+                            "overlay-1",
+                            "https://tiles.example.com/{z}/{x}/{y}.png",
+                            ReferrerPolicy: ReferrerPolicy.SameOrigin
+                        ),
+                    ]
+                )
+        );
+
+        // assert
+        var invocation = JSInterop.Invocations[CreateMapIdentifier].Single();
+        var mapOptionsPayload = invocation.Arguments[3];
+        var stylePayload = GetRequiredPropertyValue(mapOptionsPayload!, "Style");
+        var overlaysPayload = invocation.Arguments[9].Should().BeAssignableTo<Array>().Subject;
+        var overlayPayload = overlaysPayload.GetValue(0);
+
+        GetRequiredPropertyValue(stylePayload, "ReferrerPolicy").Should().Be(ReferrerPolicy.NoReferrer);
+        GetRequiredPropertyValue(overlayPayload!, "ReferrerPolicy").Should().Be(ReferrerPolicy.SameOrigin);
     }
 
     [Test, Timeout(TestTimeoutMs)]

--- a/src/Spillgebees.Blazor.Map.Tests/Runtime/Scene/MapSceneInteropCompatibilityTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Runtime/Scene/MapSceneInteropCompatibilityTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Spillgebees.Blazor.Map.Components;
 using Spillgebees.Blazor.Map.Components.Layers;
+using Spillgebees.Blazor.Map.Models;
 using Spillgebees.Blazor.Map.Models.Events;
 using Spillgebees.Blazor.Map.Runtime.Scene;
 
@@ -141,6 +142,37 @@ public class MapSceneInteropCompatibilityTests : BunitContext
             .AllSatisfy(ordering => ordering!.Stack.Should().Be("updated-stack"));
 
         JSInterop.VerifyNotInvoke(MoveMapLayerIdentifier);
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public async Task Should_include_referrer_policy_in_vector_tile_source_registration(
+        CancellationToken cancellationToken
+    )
+    {
+        // arrange
+        var cut = Render<ReferrerPolicyVectorTileHarness>();
+
+        // act
+        await cut.Instance.Map.OnMapInitializedAsync();
+
+        // assert
+        cut.WaitForAssertion(() =>
+            JSInterop.Invocations[ApplySceneMutationsIdentifier].Count.Should().BeGreaterThan(0)
+        );
+
+        var batches = JSInterop
+            .Invocations[ApplySceneMutationsIdentifier]
+            .Select(invocation => invocation.Arguments[1])
+            .OfType<MapSceneMutationBatch>()
+            .ToArray();
+
+        var addSourceMutation = batches
+            .SelectMany(batch => batch.Mutations)
+            .Single(mutation => mutation.Kind == "addSource" && mutation.SourceId == "vector-source");
+
+        addSourceMutation.SourceSpec.Should().NotBeNull();
+        addSourceMutation.SourceSpec!.Should().ContainKey("referrerPolicy");
+        addSourceMutation.SourceSpec["referrerPolicy"].Should().Be(ReferrerPolicy.StrictOriginWhenCrossOrigin);
     }
 
     public sealed class SceneRegistrationHarness : ComponentBase
@@ -376,6 +408,32 @@ public class MapSceneInteropCompatibilityTests : BunitContext
                                 }
                             )
                         );
+                        mapBuilder.CloseComponent();
+                    }
+                )
+            );
+            builder.AddComponentReferenceCapture(2, value => Map = (SgbMap)value);
+            builder.CloseComponent();
+        }
+    }
+
+    public sealed class ReferrerPolicyVectorTileHarness : ComponentBase
+    {
+        public SgbMap Map { get; private set; } = null!;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<SgbMap>(0);
+            builder.AddAttribute(
+                1,
+                "ChildContent",
+                (RenderFragment)(
+                    mapBuilder =>
+                    {
+                        mapBuilder.OpenComponent<VectorTileSource>(0);
+                        mapBuilder.AddAttribute(1, "Id", "vector-source");
+                        mapBuilder.AddAttribute(2, "Url", "https://example.com/tiles.json");
+                        mapBuilder.AddAttribute(3, "ReferrerPolicy", ReferrerPolicy.StrictOriginWhenCrossOrigin);
                         mapBuilder.CloseComponent();
                     }
                 )

--- a/src/Spillgebees.Blazor.Map.Tests/Samples/TrainTracking/TrainTrackingExampleTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Samples/TrainTracking/TrainTrackingExampleTests.cs
@@ -44,7 +44,7 @@ public class TrainTrackingExampleTests : BunitContext
         JSInterop.SetupVoid(ResizeIdentifier);
         JSInterop.Setup<double>(GetClusterExpansionZoomIdentifier).SetResult(11.2);
         JSInterop.Setup<bool>(HasStyleLayerIdentifier).SetResult(true);
-        JSInterop.Setup<double?>(GetZoomIdentifier).SetResult(8);
+        JSInterop.Setup<double?>(GetZoomIdentifier).SetResult(9);
         JSInterop.SetupVoid(FlyToIdentifier);
         JSInterop.SetupVoid(ClosePopupIdentifier);
         JSInterop.SetupVoid(SetLegendControlIdentifier);

--- a/src/Spillgebees.Blazor.Map.Tests/SgbMapTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/SgbMapTests.cs
@@ -303,6 +303,67 @@ public class SgbMapTests : BunitContext
     }
 
     [Test, Timeout(TestTimeoutMs)]
+    public void Should_propagate_referrer_policy_from_wmts_url_to_raster_source(CancellationToken cancellationToken)
+    {
+        // arrange & act
+        var style = MapStyle.FromWmtsUrl(
+            "https://server/arcgis/rest/services/Name/MapServer/WMTS",
+            "myLayer",
+            "© Example",
+            referrerPolicy: ReferrerPolicy.StrictOriginWhenCrossOrigin
+        );
+
+        // assert
+        style.RasterSource.Should().NotBeNull();
+        style.RasterSource!.ReferrerPolicy.Should().Be(ReferrerPolicy.StrictOriginWhenCrossOrigin);
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_leave_referrer_policy_null_on_wmts_url_when_not_specified(CancellationToken cancellationToken)
+    {
+        // arrange & act
+        var style = MapStyle.FromWmtsUrl(
+            "https://server/arcgis/rest/services/Name/MapServer/WMTS",
+            "myLayer",
+            "© Example"
+        );
+
+        // assert
+        style.RasterSource.Should().NotBeNull();
+        style.RasterSource!.ReferrerPolicy.Should().BeNull();
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_propagate_referrer_policy_from_arcgis_map_server_to_raster_source(
+        CancellationToken cancellationToken
+    )
+    {
+        // arrange & act
+        var style = MapStyle.FromArcGisMapServer(
+            "https://server/arcgis/rest/services/Name/MapServer",
+            "© Example",
+            referrerPolicy: ReferrerPolicy.Origin
+        );
+
+        // assert
+        style.RasterSource.Should().NotBeNull();
+        style.RasterSource!.ReferrerPolicy.Should().Be(ReferrerPolicy.Origin);
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_leave_referrer_policy_null_on_arcgis_map_server_when_not_specified(
+        CancellationToken cancellationToken
+    )
+    {
+        // arrange & act
+        var style = MapStyle.FromArcGisMapServer("https://server/arcgis/rest/services/Name/MapServer", "© Example");
+
+        // assert
+        style.RasterSource.Should().NotBeNull();
+        style.RasterSource!.ReferrerPolicy.Should().BeNull();
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
     public void Should_assign_stable_declaration_order_to_custom_layers(CancellationToken cancellationToken)
     {
         // arrange & act

--- a/src/Spillgebees.Blazor.Map.Tests/SgbMapTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/SgbMapTests.cs
@@ -262,6 +262,47 @@ public class SgbMapTests : BunitContext
     }
 
     [Test, Timeout(TestTimeoutMs)]
+    public void Should_assign_origin_referrer_policy_to_openstreetmap_standard(CancellationToken cancellationToken)
+    {
+        // arrange & act
+        var standard = MapStyle.OpenStreetMap.Standard;
+
+        // assert
+        standard.RasterSource.Should().NotBeNull();
+        standard.RasterSource!.ReferrerPolicy.Should().Be(ReferrerPolicy.Origin);
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_apply_with_referrer_policy_to_raster_tile_styles(CancellationToken cancellationToken)
+    {
+        // arrange
+        var style = MapStyle.FromRasterUrl("https://tiles.example.com/{z}/{x}/{y}.png", "© Example");
+
+        // act
+        var updatedStyle = style.WithReferrerPolicy(ReferrerPolicy.StrictOriginWhenCrossOrigin);
+
+        // assert
+        updatedStyle.RasterSource.Should().NotBeNull();
+        updatedStyle.RasterSource!.ReferrerPolicy.Should().Be(ReferrerPolicy.StrictOriginWhenCrossOrigin);
+        updatedStyle.ReferrerPolicy.Should().BeNull();
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_apply_with_referrer_policy_to_wms_styles(CancellationToken cancellationToken)
+    {
+        // arrange
+        var style = MapStyle.FromWmsUrl("https://example.com/wms", "roads", "© Example");
+
+        // act
+        var updatedStyle = style.WithReferrerPolicy(ReferrerPolicy.NoReferrer);
+
+        // assert
+        updatedStyle.WmsSource.Should().NotBeNull();
+        updatedStyle.WmsSource!.ReferrerPolicy.Should().Be(ReferrerPolicy.NoReferrer);
+        updatedStyle.ReferrerPolicy.Should().BeNull();
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
     public void Should_assign_stable_declaration_order_to_custom_layers(CancellationToken cancellationToken)
     {
         // arrange & act

--- a/src/Spillgebees.Blazor.Map/Components/Layers/VectorTileSource.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/Layers/VectorTileSource.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Spillgebees.Blazor.Map.Models;
 using Spillgebees.Blazor.Map.Runtime.Scene;
 
 namespace Spillgebees.Blazor.Map.Components.Layers;
@@ -71,6 +72,12 @@ public partial class VectorTileSource : ComponentBase, IMapSource, IAsyncDisposa
     /// </summary>
     [Parameter]
     public int? MaxZoom { get; set; }
+
+    /// <summary>
+    /// The referrer policy to apply to MapLibre-managed requests for this source.
+    /// </summary>
+    [Parameter]
+    public ReferrerPolicy? ReferrerPolicy { get; set; }
 
     private bool _isInitialized;
     private readonly List<LayerBase> _pendingLayers = [];
@@ -194,6 +201,11 @@ public partial class VectorTileSource : ComponentBase, IMapSource, IAsyncDisposa
         if (MaxZoom.HasValue)
         {
             sourceSpec["maxzoom"] = MaxZoom.Value;
+        }
+
+        if (ReferrerPolicy.HasValue)
+        {
+            sourceSpec["referrerPolicy"] = ReferrerPolicy.Value;
         }
 
         await Map!.SceneRegistry.RegisterSourceAsync(new MapSourceDescriptor(Id, sourceSpec));

--- a/src/Spillgebees.Blazor.Map/Interop/MapJs.cs
+++ b/src/Spillgebees.Blazor.Map/Interop/MapJs.cs
@@ -59,7 +59,7 @@ internal static class MapJs
             markers,
             circles,
             polylines.Select(ToJsModel).ToArray(),
-            overlays
+            overlays.Select(ToJsModel).ToArray()
         );
 
     /// <summary>
@@ -115,7 +115,13 @@ internal static class MapJs
         ILogger logger,
         ElementReference mapReference,
         List<TileOverlay> overlays
-    ) => jsRuntime.SafeInvokeVoidAsync(logger, $"{JsNamespace}.setOverlays", mapReference, overlays);
+    ) =>
+        jsRuntime.SafeInvokeVoidAsync(
+            logger,
+            $"{JsNamespace}.setOverlays",
+            mapReference,
+            overlays.Select(ToJsModel).ToArray()
+        );
 
     /// <summary>
     /// Sets the map controls.
@@ -326,8 +332,8 @@ internal static class MapJs
         {
             mapOptions.Center,
             mapOptions.Zoom,
-            mapOptions.Style,
-            Styles = mapOptions.Styles?.ToArray(),
+            Style = ToJsModel(mapOptions.Style),
+            Styles = mapOptions.Styles?.Select(ToJsModel).ToArray(),
             mapOptions.ComposedGlyphsUrl,
             mapOptions.Pitch,
             mapOptions.Bearing,
@@ -356,6 +362,44 @@ internal static class MapJs
                 : new { mapControlOptions.Center.Enable, mapControlOptions.Center.Position },
         };
 
+    private static object? ToJsModel(MapStyle? mapStyle) =>
+        mapStyle is null
+            ? null
+            : new
+            {
+                mapStyle.Id,
+                mapStyle.Url,
+                mapStyle.ReferrerPolicy,
+                RasterSource = ToJsModel(mapStyle.RasterSource),
+                WmsSource = ToJsModel(mapStyle.WmsSource),
+            };
+
+    private static object? ToJsModel(RasterTileSource? rasterTileSource) =>
+        rasterTileSource is null
+            ? null
+            : new
+            {
+                rasterTileSource.UrlTemplate,
+                rasterTileSource.Attribution,
+                rasterTileSource.TileSize,
+                rasterTileSource.ReferrerPolicy,
+            };
+
+    private static object? ToJsModel(WmsTileSource? wmsTileSource) =>
+        wmsTileSource is null
+            ? null
+            : new
+            {
+                wmsTileSource.BaseUrl,
+                wmsTileSource.Layers,
+                wmsTileSource.Attribution,
+                wmsTileSource.Format,
+                wmsTileSource.Transparent,
+                wmsTileSource.Version,
+                wmsTileSource.TileSize,
+                wmsTileSource.ReferrerPolicy,
+            };
+
     private static object ToJsModel(Polyline polyline) =>
         new
         {
@@ -365,6 +409,17 @@ internal static class MapJs
             polyline.Width,
             polyline.Opacity,
             polyline.Popup,
+        };
+
+    private static object ToJsModel(TileOverlay tileOverlay) =>
+        new
+        {
+            tileOverlay.Id,
+            tileOverlay.UrlTemplate,
+            tileOverlay.Attribution,
+            tileOverlay.TileSize,
+            tileOverlay.Opacity,
+            tileOverlay.ReferrerPolicy,
         };
 
     private static object? ToJsModel(FitBoundsOptions? fitBoundsOptions) =>

--- a/src/Spillgebees.Blazor.Map/Models/MapStyle.cs
+++ b/src/Spillgebees.Blazor.Map/Models/MapStyle.cs
@@ -6,10 +6,17 @@ namespace Spillgebees.Blazor.Map.Models;
 /// </summary>
 public record MapStyle
 {
-    private MapStyle(string? id, string? url, RasterTileSource? rasterSource, WmsTileSource? wmsSource)
+    private MapStyle(
+        string? id,
+        string? url,
+        ReferrerPolicy? referrerPolicy,
+        RasterTileSource? rasterSource,
+        WmsTileSource? wmsSource
+    )
     {
         Id = id;
         Url = url;
+        ReferrerPolicy = referrerPolicy;
         RasterSource = rasterSource;
         WmsSource = wmsSource;
     }
@@ -25,14 +32,19 @@ public record MapStyle
     public string? Url { get; }
 
     /// <summary>
+    /// The referrer policy to apply to MapLibre-managed requests for this style.
+    /// </summary>
+    public ReferrerPolicy? ReferrerPolicy { get; init; }
+
+    /// <summary>
     /// The raster tile source configuration, when using raster tiles directly.
     /// </summary>
-    public RasterTileSource? RasterSource { get; }
+    public RasterTileSource? RasterSource { get; init; }
 
     /// <summary>
     /// The WMS tile source configuration, when using a WMS endpoint.
     /// </summary>
-    public WmsTileSource? WmsSource { get; }
+    public WmsTileSource? WmsSource { get; init; }
 
     /// <summary>
     /// Returns a copy of this style with the given stable identifier.
@@ -51,10 +63,31 @@ public record MapStyle
     }
 
     /// <summary>
+    /// Returns a copy of this style with the given referrer policy.
+    /// </summary>
+    public MapStyle WithReferrerPolicy(ReferrerPolicy? referrerPolicy)
+    {
+        if (RasterSource is not null)
+        {
+            return this with { RasterSource = RasterSource with { ReferrerPolicy = referrerPolicy } };
+        }
+
+        if (WmsSource is not null)
+        {
+            return this with { WmsSource = WmsSource with { ReferrerPolicy = referrerPolicy } };
+        }
+
+        return this with
+        {
+            ReferrerPolicy = referrerPolicy,
+        };
+    }
+
+    /// <summary>
     /// Creates a <see cref="MapStyle"/> from a MapLibre style specification URL.
     /// </summary>
     /// <param name="url">The URL to a MapLibre-compatible style JSON.</param>
-    public static MapStyle FromUrl(string url) => new(null, url, null, null);
+    public static MapStyle FromUrl(string url) => new(null, url, null, null, null);
 
     /// <summary>
     /// Creates a <see cref="MapStyle"/> from a raster tile URL template.
@@ -62,8 +95,13 @@ public record MapStyle
     /// <param name="urlTemplate">The tile URL template with <c>{z}</c>, <c>{x}</c>, <c>{y}</c> placeholders.</param>
     /// <param name="attribution">The attribution text to display on the map.</param>
     /// <param name="tileSize">The tile size in pixels. Default is 256.</param>
-    public static MapStyle FromRasterUrl(string urlTemplate, string attribution, int tileSize = 256) =>
-        new(null, null, new RasterTileSource(urlTemplate, attribution, tileSize), null);
+    /// <param name="referrerPolicy">The referrer policy to apply to tile requests.</param>
+    public static MapStyle FromRasterUrl(
+        string urlTemplate,
+        string attribution,
+        int tileSize = 256,
+        ReferrerPolicy? referrerPolicy = null
+    ) => new(null, null, null, new RasterTileSource(urlTemplate, attribution, tileSize, referrerPolicy), null);
 
     /// <summary>
     /// Creates a <see cref="MapStyle"/> from a WMS endpoint.
@@ -75,6 +113,7 @@ public record MapStyle
     /// <param name="transparent">Whether to request transparent tiles. Default is <see langword="false"/>.</param>
     /// <param name="version">The WMS service version. Default is <c>"1.1.1"</c>.</param>
     /// <param name="tileSize">The tile size in pixels. Default is 256.</param>
+    /// <param name="referrerPolicy">The referrer policy to apply to tile requests.</param>
     public static MapStyle FromWmsUrl(
         string baseUrl,
         string layers,
@@ -82,8 +121,16 @@ public record MapStyle
         string format = "image/png",
         bool transparent = false,
         string version = "1.1.1",
-        int tileSize = 256
-    ) => new(null, null, null, new WmsTileSource(baseUrl, layers, attribution, format, transparent, version, tileSize));
+        int tileSize = 256,
+        ReferrerPolicy? referrerPolicy = null
+    ) =>
+        new(
+            null,
+            null,
+            null,
+            null,
+            new WmsTileSource(baseUrl, layers, attribution, format, transparent, version, tileSize, referrerPolicy)
+        );
 
     /// <summary>
     /// Creates a <see cref="MapStyle"/> from a WMTS (Web Map Tile Service) endpoint.
@@ -156,7 +203,8 @@ public record MapStyle
         public static MapStyle Standard =>
             FromRasterUrl(
                     "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
-                    "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors"
+                    "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+                    referrerPolicy: Models.ReferrerPolicy.Origin
                 )
                 .WithId("sgb-openstreetmap-standard");
     }
@@ -168,7 +216,13 @@ public record MapStyle
 /// <param name="UrlTemplate">The tile URL template with <c>{z}</c>, <c>{x}</c>, <c>{y}</c> placeholders.</param>
 /// <param name="Attribution">The attribution text to display on the map.</param>
 /// <param name="TileSize">The tile size in pixels.</param>
-public sealed record RasterTileSource(string UrlTemplate, string Attribution, int TileSize);
+/// <param name="ReferrerPolicy">The referrer policy to apply to tile requests.</param>
+public sealed record RasterTileSource(
+    string UrlTemplate,
+    string Attribution,
+    int TileSize,
+    ReferrerPolicy? ReferrerPolicy = null
+);
 
 /// <summary>
 /// Configuration for a WMS tile source.
@@ -180,6 +234,7 @@ public sealed record RasterTileSource(string UrlTemplate, string Attribution, in
 /// <param name="Transparent">Whether to request transparent tiles.</param>
 /// <param name="Version">The WMS service version.</param>
 /// <param name="TileSize">The tile size in pixels.</param>
+/// <param name="ReferrerPolicy">The referrer policy to apply to tile requests.</param>
 public sealed record WmsTileSource(
     string BaseUrl,
     string Layers,
@@ -187,5 +242,6 @@ public sealed record WmsTileSource(
     string Format,
     bool Transparent,
     string Version,
-    int TileSize
+    int TileSize,
+    ReferrerPolicy? ReferrerPolicy = null
 );

--- a/src/Spillgebees.Blazor.Map/Models/MapStyle.cs
+++ b/src/Spillgebees.Blazor.Map/Models/MapStyle.cs
@@ -143,6 +143,7 @@ public record MapStyle
     /// <param name="style">The WMTS style. Default is <c>"default"</c>.</param>
     /// <param name="format">The image format extension. Default is <c>"png"</c>.</param>
     /// <param name="tileSize">The tile size in pixels. Default is 256.</param>
+    /// <param name="referrerPolicy">The referrer policy to apply to tile requests.</param>
     public static MapStyle FromWmtsUrl(
         string baseUrl,
         string layer,
@@ -150,12 +151,13 @@ public record MapStyle
         string tileMatrixSet = "default028mm",
         string style = "default",
         string format = "png",
-        int tileSize = 256
+        int tileSize = 256,
+        ReferrerPolicy? referrerPolicy = null
     )
     {
         var urlTemplate =
             $"{baseUrl.TrimEnd('/')}/tile/1.0.0/{layer}/{style}/{tileMatrixSet}/{{z}}/{{y}}/{{x}}.{format}";
-        return FromRasterUrl(urlTemplate, attribution, tileSize);
+        return FromRasterUrl(urlTemplate, attribution, tileSize, referrerPolicy);
     }
 
     /// <summary>
@@ -164,10 +166,16 @@ public record MapStyle
     /// <param name="mapServerUrl">The MapServer URL (e.g., <c>https://server/arcgis/rest/services/Name/MapServer</c>).</param>
     /// <param name="attribution">The attribution text to display on the map.</param>
     /// <param name="tileSize">The tile size in pixels. Default is 256.</param>
-    public static MapStyle FromArcGisMapServer(string mapServerUrl, string attribution, int tileSize = 256)
+    /// <param name="referrerPolicy">The referrer policy to apply to tile requests.</param>
+    public static MapStyle FromArcGisMapServer(
+        string mapServerUrl,
+        string attribution,
+        int tileSize = 256,
+        ReferrerPolicy? referrerPolicy = null
+    )
     {
         var urlTemplate = $"{mapServerUrl.TrimEnd('/')}/tile/{{z}}/{{y}}/{{x}}";
-        return FromRasterUrl(urlTemplate, attribution, tileSize);
+        return FromRasterUrl(urlTemplate, attribution, tileSize, referrerPolicy);
     }
 
     /// <summary>

--- a/src/Spillgebees.Blazor.Map/Models/ReferrerPolicy.cs
+++ b/src/Spillgebees.Blazor.Map/Models/ReferrerPolicy.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace Spillgebees.Blazor.Map.Models;
+
+/// <summary>
+/// Controls the referrer information sent with network requests.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ReferrerPolicy>))]
+public enum ReferrerPolicy
+{
+    [JsonStringEnumMemberName("no-referrer")]
+    NoReferrer,
+
+    [JsonStringEnumMemberName("no-referrer-when-downgrade")]
+    NoReferrerWhenDowngrade,
+
+    [JsonStringEnumMemberName("origin")]
+    Origin,
+
+    [JsonStringEnumMemberName("origin-when-cross-origin")]
+    OriginWhenCrossOrigin,
+
+    [JsonStringEnumMemberName("same-origin")]
+    SameOrigin,
+
+    [JsonStringEnumMemberName("strict-origin")]
+    StrictOrigin,
+
+    [JsonStringEnumMemberName("strict-origin-when-cross-origin")]
+    StrictOriginWhenCrossOrigin,
+
+    [JsonStringEnumMemberName("unsafe-url")]
+    UnsafeUrl,
+}

--- a/src/Spillgebees.Blazor.Map/Models/TileOverlay.cs
+++ b/src/Spillgebees.Blazor.Map/Models/TileOverlay.cs
@@ -12,12 +12,14 @@ namespace Spillgebees.Blazor.Map.Models;
 /// <param name="Attribution">The attribution text to display on the map. Default is empty.</param>
 /// <param name="TileSize">The tile size in pixels. Default is 256.</param>
 /// <param name="Opacity">The opacity of the overlay (0.0–1.0). Default is 1.0.</param>
+/// <param name="ReferrerPolicy">The referrer policy to apply to tile requests.</param>
 public record TileOverlay(
     string Id,
     string UrlTemplate,
     string Attribution = "",
     int TileSize = 256,
-    double Opacity = 1.0
+    double Opacity = 1.0,
+    ReferrerPolicy? ReferrerPolicy = null
 )
 {
     /// <summary>
@@ -33,6 +35,7 @@ public record TileOverlay(
     /// <param name="version">The WMS service version. Default is <c>"1.1.1"</c>.</param>
     /// <param name="tileSize">The tile size in pixels. Default is 256.</param>
     /// <param name="opacity">The overlay opacity. Default is 1.0.</param>
+    /// <param name="referrerPolicy">The referrer policy to apply to tile requests.</param>
     public static TileOverlay FromWms(
         string id,
         string baseUrl,
@@ -42,7 +45,8 @@ public record TileOverlay(
         bool transparent = true,
         string version = "1.1.1",
         int tileSize = 256,
-        double opacity = 1.0
+        double opacity = 1.0,
+        ReferrerPolicy? referrerPolicy = null
     )
     {
         // WMS 1.3.0 uses CRS; earlier versions use SRS
@@ -53,7 +57,7 @@ public record TileOverlay(
             + $"&{crsParam}=EPSG:3857&STYLES=&WIDTH={tileSize}&HEIGHT={tileSize}"
             + "&BBOX={bbox-epsg-3857}";
 
-        return new TileOverlay(id, url, attribution, tileSize, opacity);
+        return new TileOverlay(id, url, attribution, tileSize, opacity, referrerPolicy);
     }
 
     /// <summary>
@@ -72,6 +76,7 @@ public record TileOverlay(
     /// <param name="format">The image format extension. Default is <c>"png"</c>.</param>
     /// <param name="tileSize">The tile size in pixels. Default is 256.</param>
     /// <param name="opacity">The overlay opacity. Default is 1.0.</param>
+    /// <param name="referrerPolicy">The referrer policy to apply to tile requests.</param>
     public static TileOverlay FromWmts(
         string id,
         string baseUrl,
@@ -81,14 +86,15 @@ public record TileOverlay(
         string style = "default",
         string format = "png",
         int tileSize = 256,
-        double opacity = 1.0
+        double opacity = 1.0,
+        ReferrerPolicy? referrerPolicy = null
     )
     {
         // WMTS RESTful tile URL pattern:
         // {baseUrl}/tile/1.0.0/{layer}/{style}/{tileMatrixSet}/{z}/{y}/{x}.{format}
         var url = $"{baseUrl.TrimEnd('/')}/tile/1.0.0/{layer}/{style}/{tileMatrixSet}/{{z}}/{{y}}/{{x}}.{format}";
 
-        return new TileOverlay(id, url, attribution, tileSize, opacity);
+        return new TileOverlay(id, url, attribution, tileSize, opacity, referrerPolicy);
     }
 
     /// <summary>
@@ -103,18 +109,20 @@ public record TileOverlay(
     /// <param name="attribution">The attribution text. Default is empty.</param>
     /// <param name="tileSize">The tile size in pixels. Default is 256.</param>
     /// <param name="opacity">The overlay opacity. Default is 1.0.</param>
+    /// <param name="referrerPolicy">The referrer policy to apply to tile requests.</param>
     public static TileOverlay FromArcGisMapServer(
         string id,
         string mapServerUrl,
         string attribution = "",
         int tileSize = 256,
-        double opacity = 1.0
+        double opacity = 1.0,
+        ReferrerPolicy? referrerPolicy = null
     )
     {
         // ArcGIS MapServer tile URL pattern:
         // {mapServerUrl}/tile/{z}/{y}/{x}
         var url = $"{mapServerUrl.TrimEnd('/')}/tile/{{z}}/{{y}}/{{x}}";
 
-        return new TileOverlay(id, url, attribution, tileSize, opacity);
+        return new TileOverlay(id, url, attribution, tileSize, opacity, referrerPolicy);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added referrer-policy support for map styles, raster/WMS tile sources, and tile overlays so network requests honor per-style or per-overlay policies.
  * Eight referrer-policy options are supported and preserved across composition, overlay fetching, and map updates.

* **Dependencies**
  * Bumped MapLibre GL from 5.20.2 to 5.21.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->