### PR TITLE
:bug: fix attribution control regression

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
@@ -886,7 +886,6 @@ describe("createMap", () => {
         maxZoom: 18,
         interactive: false,
         cooperativeGestures: true,
-        attributionControl: {},
       }),
     );
   });

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.ts
@@ -873,7 +873,6 @@ export function createMap(
       : undefined,
     interactive: mapOptions.interactive,
     cooperativeGestures: mapOptions.cooperativeGestures,
-    attributionControl: {},
     transformRequest,
   });
 


### PR DESCRIPTION
Attribution control styling and functionality regressed after recent API reworks. This PR reinstates the original behaviour.