### PR TITLE
✨ add `PixelRatio` setting

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/src/controls/centerControl.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/controls/centerControl.test.ts
@@ -33,6 +33,8 @@ function createDefaultMapOptions(overrides?: Partial<IMapOptions>): IMapOptions 
     interactive: true,
     cooperativeGestures: false,
     webFonts: null,
+    pixelRatioMode: "browserDefault",
+    pixelRatio: null,
     ...overrides,
   };
 }

--- a/src/Spillgebees.Blazor.Map.Assets/src/features/markers.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/features/markers.test.ts
@@ -34,6 +34,8 @@ function createDefaultMapOptions(overrides?: Partial<IMapOptions>): IMapOptions 
     interactive: true,
     cooperativeGestures: false,
     webFonts: null,
+    pixelRatioMode: "browserDefault",
+    pixelRatio: null,
     ...overrides,
   };
 }

--- a/src/Spillgebees.Blazor.Map.Assets/src/features/shapes.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/features/shapes.test.ts
@@ -36,6 +36,8 @@ function createDefaultMapOptions(): IMapOptions {
     interactive: true,
     cooperativeGestures: false,
     webFonts: null,
+    pixelRatioMode: "browserDefault",
+    pixelRatio: null,
   };
 }
 

--- a/src/Spillgebees.Blazor.Map.Assets/src/interfaces/map.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/interfaces/map.ts
@@ -26,6 +26,8 @@ export interface IMapOptions {
   interactive: boolean;
   cooperativeGestures: boolean;
   webFonts: string[] | null;
+  pixelRatioMode: "browserDefault" | "roundedUpDevicePixelRatio";
+  pixelRatio: number | null;
 }
 
 export interface IMapBounds {

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
@@ -1707,8 +1707,9 @@ describe("setMapOptions", () => {
     expect(mockMap.setPixelRatio).toHaveBeenCalledWith(2);
   });
 
-  it("should clear pixel ratio override when returning to browser default", () => {
+  it("should restore browser pixel ratio when returning to browser default", () => {
     // arrange
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1.25 });
     const mapElement = document.createElement("div");
     const dotNetHelper = createMockDotNetHelper();
     createMap(
@@ -1729,7 +1730,7 @@ describe("setMapOptions", () => {
     setMapOptions(mapElement, createDefaultMapOptions());
 
     // assert
-    expect(mockMap.setPixelRatio).toHaveBeenCalledWith(null);
+    expect(mockMap.setPixelRatio).toHaveBeenCalledWith(1.25);
   });
 
   it("should not set pixel ratio for browser default to browser default updates", () => {

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.test.ts
@@ -46,6 +46,9 @@ import * as composition from "./styles/composition";
 const applyOverlayStylesSpy = vi.spyOn(composition, "applyOverlayStyles");
 const validateComposedGlyphsSpy = vi.spyOn(composition, "validateComposedGlyphs");
 
+// biome-ignore lint/security/noSecrets: Map option mode literal, not a secret.
+const roundedUpDevicePixelRatioMode = "roundedUpDevicePixelRatio";
+
 function createDefaultMapOptions(overrides?: Partial<IMapOptions>): IMapOptions {
   return {
     center: { latitude: 51.505, longitude: -0.09 },
@@ -65,6 +68,8 @@ function createDefaultMapOptions(overrides?: Partial<IMapOptions>): IMapOptions 
     interactive: true,
     cooperativeGestures: false,
     webFonts: null,
+    pixelRatioMode: "browserDefault",
+    pixelRatio: null,
     ...overrides,
   };
 }
@@ -890,6 +895,153 @@ describe("createMap", () => {
     );
   });
 
+  it("should omit pixelRatio from MapLibre constructor by default", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions(),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    const constructorOptions = getMockMapConstructor().mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(constructorOptions).not.toHaveProperty("pixelRatio");
+  });
+
+  it("should pass rounded device pixel ratio to MapLibre constructor", () => {
+    // arrange
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1.25 });
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions({ pixelRatioMode: roundedUpDevicePixelRatioMode }),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    expect(getMockMapConstructor()).toHaveBeenCalledWith(expect.objectContaining({ pixelRatio: 2 }));
+  });
+
+  it("should keep whole-number device pixel ratio unchanged", () => {
+    // arrange
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 2 });
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions({ pixelRatioMode: roundedUpDevicePixelRatioMode }),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    expect(getMockMapConstructor()).toHaveBeenCalledWith(expect.objectContaining({ pixelRatio: 2 }));
+  });
+
+  it("should pass explicit pixel ratio to MapLibre constructor", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions({ pixelRatio: 1.5 }),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    expect(getMockMapConstructor()).toHaveBeenCalledWith(expect.objectContaining({ pixelRatio: 1.5 }));
+  });
+
+  it("should prefer explicit pixel ratio over rounded mode", () => {
+    // arrange
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1.25 });
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+
+    // act
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions({ pixelRatioMode: roundedUpDevicePixelRatioMode, pixelRatio: 1.5 }),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+
+    // assert
+    expect(getMockMapConstructor()).toHaveBeenCalledWith(expect.objectContaining({ pixelRatio: 1.5 }));
+  });
+
+  it.each([
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])("should reject invalid explicit pixel ratio %s", (pixelRatio) => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+
+    // act/assert
+    expect(() =>
+      createMap(
+        dotNetHelper,
+        "OnMapInitialized",
+        mapElement,
+        createDefaultMapOptions({ pixelRatio }),
+        createDefaultControlOptions(),
+        "light",
+        [],
+        [],
+        [],
+        [],
+      ),
+    ).toThrow("pixelRatio must be greater than zero.");
+  });
+
   it("should pass undefined for minZoom/maxZoom when null", () => {
     // arrange
     const mapElement = document.createElement("div");
@@ -1502,6 +1654,107 @@ describe("setMapOptions", () => {
     // assert
     expect(mockMap.setPitch).toHaveBeenCalledWith(60);
     expect(mockMap.setBearing).toHaveBeenCalledWith(180);
+  });
+
+  it("should apply changed pixel ratio", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions(),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+    const mockMap = getLatestMockMapInstance()!;
+
+    // act
+    setMapOptions(mapElement, createDefaultMapOptions({ pixelRatio: 1.5 }));
+
+    // assert
+    expect(mockMap.setPixelRatio).toHaveBeenCalledWith(1.5);
+  });
+
+  it("should apply rounded changed pixel ratio", () => {
+    // arrange
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1.25 });
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions(),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+    const mockMap = getLatestMockMapInstance()!;
+
+    // act
+    setMapOptions(mapElement, createDefaultMapOptions({ pixelRatioMode: roundedUpDevicePixelRatioMode }));
+
+    // assert
+    expect(mockMap.setPixelRatio).toHaveBeenCalledWith(2);
+  });
+
+  it("should clear pixel ratio override when returning to browser default", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions({ pixelRatio: 1.5 }),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+    const mockMap = getLatestMockMapInstance()!;
+
+    // act
+    setMapOptions(mapElement, createDefaultMapOptions());
+
+    // assert
+    expect(mockMap.setPixelRatio).toHaveBeenCalledWith(null);
+  });
+
+  it("should not set pixel ratio for browser default to browser default updates", () => {
+    // arrange
+    const mapElement = document.createElement("div");
+    const dotNetHelper = createMockDotNetHelper();
+    createMap(
+      dotNetHelper,
+      "OnMapInitialized",
+      mapElement,
+      createDefaultMapOptions(),
+      createDefaultControlOptions(),
+      "light",
+      [],
+      [],
+      [],
+      [],
+    );
+    const mockMap = getLatestMockMapInstance()!;
+
+    // act
+    setMapOptions(mapElement, createDefaultMapOptions());
+
+    // assert
+    expect(mockMap.setPixelRatio).not.toHaveBeenCalled();
   });
 
   it("should not throw for unknown elements", () => {

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.ts
@@ -432,6 +432,45 @@ function getBaseStyleId(mapOptions: IMapOptions): string | null {
   return stylesList[0]?.id ?? null;
 }
 
+// biome-ignore lint/security/noSecrets: Map option mode literal, not a secret.
+const roundedUpDevicePixelRatioMode = "roundedUpDevicePixelRatio";
+const mapPixelRatioOverrides = new WeakMap<MapLibreMap, number>();
+
+function resolvePixelRatio(mapOptions: IMapOptions): number | undefined {
+  if (mapOptions.pixelRatio != null) {
+    if (!Number.isFinite(mapOptions.pixelRatio) || mapOptions.pixelRatio <= 0) {
+      throw new Error("pixelRatio must be greater than zero.");
+    }
+
+    return mapOptions.pixelRatio;
+  }
+
+  if (mapOptions.pixelRatioMode === roundedUpDevicePixelRatioMode) {
+    return Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+  }
+
+  return undefined;
+}
+
+function syncMapPixelRatio(map: MapLibreMap, mapOptions: IMapOptions): void {
+  const nextPixelRatio = resolvePixelRatio(mapOptions);
+  const currentPixelRatio = mapPixelRatioOverrides.get(map);
+
+  if (nextPixelRatio === undefined) {
+    if (currentPixelRatio !== undefined) {
+      map.setPixelRatio(null as unknown as number);
+      mapPixelRatioOverrides.delete(map);
+    }
+
+    return;
+  }
+
+  if (currentPixelRatio !== nextPixelRatio) {
+    map.setPixelRatio(nextPixelRatio);
+    mapPixelRatioOverrides.set(map, nextPixelRatio);
+  }
+}
+
 function replayRegisteredImages(mapElement: HTMLElement): void | Promise<void> {
   const map = window.Spillgebees.Map.maps.get(mapElement);
   if (!map) {
@@ -853,6 +892,7 @@ export function createMap(
   const baseStyle = buildStyleFromOptions(stylesList[0] ?? null);
   const overlayStyles = getComposedOverlayStyles(mapOptions);
   const overlayStyleUrls = overlayStyles.map((style) => style.url);
+  const pixelRatio = resolvePixelRatio(mapOptions);
 
   let map: MapLibreMap | null = null;
   const transformRequest = createMapTransformRequest(() => map);
@@ -874,7 +914,11 @@ export function createMap(
     interactive: mapOptions.interactive,
     cooperativeGestures: mapOptions.cooperativeGestures,
     transformRequest,
+    ...(pixelRatio === undefined ? {} : { pixelRatio }),
   });
+  if (pixelRatio !== undefined) {
+    mapPixelRatioOverrides.set(map, pixelRatio);
+  }
 
   // Store the map instance
   window.Spillgebees.Map.maps.set(mapElement, map);
@@ -1062,6 +1106,7 @@ export function setMapOptions(mapElement: HTMLElement, mapOptions: IMapOptions):
     (window.Spillgebees.Map.overlays.get(map) ?? new Map()).values(),
   ) as ITileOverlay[];
   updateMapRequestContext(map, mapOptions, existingOverlays);
+  syncMapPixelRatio(map, mapOptions);
 
   // Update pitch and bearing
   map.setPitch(mapOptions.pitch);

--- a/src/Spillgebees.Blazor.Map.Assets/src/map.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/map.ts
@@ -436,6 +436,10 @@ function getBaseStyleId(mapOptions: IMapOptions): string | null {
 const roundedUpDevicePixelRatioMode = "roundedUpDevicePixelRatio";
 const mapPixelRatioOverrides = new WeakMap<MapLibreMap, number>();
 
+function getBrowserPixelRatio(): number {
+  return window.devicePixelRatio || 1;
+}
+
 function resolvePixelRatio(mapOptions: IMapOptions): number | undefined {
   if (mapOptions.pixelRatio != null) {
     if (!Number.isFinite(mapOptions.pixelRatio) || mapOptions.pixelRatio <= 0) {
@@ -446,7 +450,7 @@ function resolvePixelRatio(mapOptions: IMapOptions): number | undefined {
   }
 
   if (mapOptions.pixelRatioMode === roundedUpDevicePixelRatioMode) {
-    return Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+    return Math.max(1, Math.ceil(getBrowserPixelRatio()));
   }
 
   return undefined;
@@ -458,8 +462,13 @@ function syncMapPixelRatio(map: MapLibreMap, mapOptions: IMapOptions): void {
 
   if (nextPixelRatio === undefined) {
     if (currentPixelRatio !== undefined) {
-      map.setPixelRatio(null as unknown as number);
-      mapPixelRatioOverrides.delete(map);
+      const browserPixelRatio = getBrowserPixelRatio();
+
+      if (currentPixelRatio !== browserPixelRatio) {
+        map.setPixelRatio(browserPixelRatio);
+      }
+
+      mapPixelRatioOverrides.set(map, browserPixelRatio);
     }
 
     return;

--- a/src/Spillgebees.Blazor.Map.Assets/src/runtime/sceneMutations.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/runtime/sceneMutations.test.ts
@@ -30,6 +30,8 @@ describe.sequential("applySceneMutations", () => {
       interactive: true,
       cooperativeGestures: false,
       webFonts: null,
+      pixelRatioMode: "browserDefault",
+      pixelRatio: null,
       ...overrides,
     };
   }

--- a/src/Spillgebees.Blazor.Map.Assets/src/sources/geojson.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/sources/geojson.test.ts
@@ -303,6 +303,8 @@ function createDefaultMapOptions(overrides?: Partial<IMapOptions>): IMapOptions 
     interactive: true,
     cooperativeGestures: false,
     webFonts: null,
+    pixelRatioMode: "browserDefault",
+    pixelRatio: null,
     ...overrides,
   };
 }

--- a/src/Spillgebees.Blazor.Map.Assets/test/maplibreMock.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/test/maplibreMock.ts
@@ -14,6 +14,7 @@ export interface MockMapInstance {
   setMaxBounds: ReturnType<typeof vi.fn>;
   setMinZoom: ReturnType<typeof vi.fn>;
   setMaxZoom: ReturnType<typeof vi.fn>;
+  setPixelRatio: ReturnType<typeof vi.fn>;
   addControl: ReturnType<typeof vi.fn>;
   removeControl: ReturnType<typeof vi.fn>;
   getContainer: ReturnType<typeof vi.fn>;
@@ -175,6 +176,7 @@ const MockMapConstructor = vi.fn().mockImplementation(function (
   this.setMaxBounds = vi.fn();
   this.setMinZoom = vi.fn();
   this.setMaxZoom = vi.fn();
+  this.setPixelRatio = vi.fn();
   this.addControl = vi.fn();
   this.removeControl = vi.fn();
   this.getContainer = vi.fn().mockReturnValue(document.createElement("div"));

--- a/src/Spillgebees.Blazor.Map.Docs/Pages/Components/SgbMapPage.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Pages/Components/SgbMapPage.razor
@@ -77,6 +77,12 @@
     <StyleSwitchingExample />
 </ExampleView>
 
+<h2 id="pixel_ratio">// pixel_ratio</h2>
+<p>Use <code>PixelRatioMode</code> or <code>PixelRatio</code> to opt into MapLibre canvas pixel ratio control. The default preserves browser behavior. Rounded DPR can improve label sharpness on fractional display scaling such as 125%, at the cost of higher canvas resolution and GPU memory use.</p>
+<ExampleView TComponent="PixelRatioExample">
+    <PixelRatioExample />
+</ExampleView>
+
 <h2 id="themes">// themes</h2>
 <p>The <code>Theme</code> parameter controls UI chrome appearance (controls, popups, attribution). It has no effect on tile rendering. Pass <code>MapTheme.Dark</code> to switch to dark chrome. Hover the marker below and toggle themes to see the popup styling change.</p>
 <ExampleView TComponent="ThemeSwitchingExample">

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/PixelRatioExample.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/PixelRatioExample.razor
@@ -1,0 +1,112 @@
+@inject IJSRuntime JsRuntime
+
+<div class="sample-btn-row">
+    <button type="button"
+            class="sample-btn @(_activeMode == "browser" ? "active" : "")"
+            aria-pressed="@(_activeMode == "browser")"
+            @onclick="UseBrowserDefault">
+        Browser default
+    </button>
+    <button type="button"
+            class="sample-btn @(_activeMode == "rounded" ? "active" : "")"
+            aria-pressed="@(_activeMode == "rounded")"
+            @onclick="UseRoundedDpr">
+        Rounded DPR
+    </button>
+    <button type="button"
+            class="sample-btn @(_activeMode == "explicit" ? "active" : "")"
+            aria-pressed="@(_activeMode == "explicit")"
+            @onclick="UseExplicitRatio">
+        Explicit 1.25x
+    </button>
+</div>
+
+<SgbMap MapOptions="@_mapOptions"
+        Height="400px"
+        Width="100%">
+    <MapControls>
+        <MapNavigationControl />
+        <MapCustomControl Id="pixel-ratio-status"
+                          Position="ControlPosition.TopLeft"
+                          Order="20"
+                          Class="docs-pixel-ratio-control-shell">
+            <div class="docs-pixel-ratio-control"
+                 role="status"
+                 aria-live="polite">
+                <span class="docs-pixel-ratio-label">Browser default</span>
+                <strong>@BrowserDefaultPixelRatioDisplay</strong>
+                <span class="docs-pixel-ratio-label">Rounded DPR</span>
+                <strong>@RoundedPixelRatioDisplay</strong>
+                <span class="docs-pixel-ratio-label">Selected map</span>
+                <strong>@SelectedPixelRatioDisplay</strong>
+            </div>
+        </MapCustomControl>
+    </MapControls>
+</SgbMap>
+
+@code {
+    private string _activeMode = "browser";
+    private double? _devicePixelRatio;
+
+    private MapOptions _mapOptions = new(
+        Center: new Coordinate(49.75, 6.10),
+        Zoom: 9,
+        Style: MapStyle.OpenFreeMap.Positron
+    );
+
+    private string BrowserDefaultPixelRatioDisplay => FormatPixelRatio(_devicePixelRatio);
+
+    private string RoundedPixelRatioDisplay =>
+        _devicePixelRatio is { } value ? FormatPixelRatio(Math.Max(1, Math.Ceiling(value))) : "Checking...";
+
+    private string SelectedPixelRatioDisplay =>
+        _mapOptions.PixelRatio switch
+        {
+            { } pixelRatio => FormatPixelRatio(pixelRatio),
+            _ when _mapOptions.PixelRatioMode == MapPixelRatioMode.RoundedUpDevicePixelRatio => RoundedPixelRatioDisplay,
+            _ => BrowserDefaultPixelRatioDisplay,
+        };
+
+    private static string FormatPixelRatio(double? value) => value is { } pixelRatio ? $"{pixelRatio:0.##}x" : "Checking...";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        _devicePixelRatio = await JsRuntime.InvokeAsync<double>("SpillgebeesDocs.getDevicePixelRatio");
+        StateHasChanged();
+    }
+
+    private void UseBrowserDefault()
+    {
+        _activeMode = "browser";
+        _mapOptions = _mapOptions with
+        {
+            PixelRatioMode = MapPixelRatioMode.BrowserDefault,
+            PixelRatio = null,
+        };
+    }
+
+    private void UseRoundedDpr()
+    {
+        _activeMode = "rounded";
+        _mapOptions = _mapOptions with
+        {
+            PixelRatioMode = MapPixelRatioMode.RoundedUpDevicePixelRatio,
+            PixelRatio = null,
+        };
+    }
+
+    private void UseExplicitRatio()
+    {
+        _activeMode = "explicit";
+        _mapOptions = _mapOptions with
+        {
+            PixelRatioMode = MapPixelRatioMode.BrowserDefault,
+            PixelRatio = 1.25,
+        };
+    }
+}

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/PixelRatioExample.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/PixelRatioExample.razor
@@ -3,18 +3,21 @@
 <div class="sample-btn-row">
     <button type="button"
             class="sample-btn @(_activeMode == "browser" ? "active" : "")"
+            data-test="pixel-ratio-browser-default"
             aria-pressed="@(_activeMode == "browser")"
             @onclick="UseBrowserDefault">
         Browser default
     </button>
     <button type="button"
             class="sample-btn @(_activeMode == "rounded" ? "active" : "")"
+            data-test="pixel-ratio-rounded-dpr"
             aria-pressed="@(_activeMode == "rounded")"
             @onclick="UseRoundedDpr">
         Rounded DPR
     </button>
     <button type="button"
             class="sample-btn @(_activeMode == "explicit" ? "active" : "")"
+            data-test="pixel-ratio-explicit"
             aria-pressed="@(_activeMode == "explicit")"
             @onclick="UseExplicitRatio">
         Explicit 1.25x
@@ -76,7 +79,15 @@
             return;
         }
 
-        _devicePixelRatio = await JsRuntime.InvokeAsync<double>("SpillgebeesDocs.getDevicePixelRatio");
+        try
+        {
+            _devicePixelRatio = await JsRuntime.InvokeAsync<double>("SpillgebeesDocs.getDevicePixelRatio");
+        }
+        catch (Exception)
+        {
+            _devicePixelRatio = 1.0;
+        }
+
         StateHasChanged();
     }
 

--- a/src/Spillgebees.Blazor.Map.Docs/wwwroot/index.html
+++ b/src/Spillgebees.Blazor.Map.Docs/wwwroot/index.html
@@ -43,10 +43,34 @@
             border-color: var(--color-primary);
             background: rgba(200, 160, 80, 0.08);
         }
+
+        .docs-pixel-ratio-control {
+            display: grid;
+            gap: 2px;
+            padding: 7px 10px;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            color: var(--color-text);
+            font-family: var(--font-mono);
+            font-size: 12px;
+            line-height: 1.25;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+        }
+
+        .docs-pixel-ratio-label {
+            color: var(--color-text-muted);
+            font-size: 10px;
+            text-transform: uppercase;
+        }
     </style>
 </head>
 <body>
     <div id="app">Loading...</div>
+    <script>
+        window.SpillgebeesDocs = {
+            getDevicePixelRatio: () => window.devicePixelRatio || 1
+        };
+    </script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>

--- a/src/Spillgebees.Blazor.Map.Docs/wwwroot/index.html
+++ b/src/Spillgebees.Blazor.Map.Docs/wwwroot/index.html
@@ -67,9 +67,8 @@
 <body>
     <div id="app">Loading...</div>
     <script>
-        window.SpillgebeesDocs = {
-            getDevicePixelRatio: () => window.devicePixelRatio || 1
-        };
+        window.SpillgebeesDocs = window.SpillgebeesDocs || {};
+        window.SpillgebeesDocs.getDevicePixelRatio = () => window.devicePixelRatio || 1;
     </script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>

--- a/src/Spillgebees.Blazor.Map.Tests/Interop/MapJsInteropPayloadTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Interop/MapJsInteropPayloadTests.cs
@@ -200,6 +200,55 @@ public class MapJsInteropPayloadTests : BunitContext
     }
 
     [Test, Timeout(TestTimeoutMs)]
+    public void Should_send_default_pixel_ratio_options_when_initializing_map(CancellationToken cancellationToken)
+    {
+        // arrange & act
+        Render<SgbMap>();
+
+        // assert
+        var invocation = JSInterop.Invocations[CreateMapIdentifier].Single();
+        var mapOptionsPayload = invocation.Arguments[3];
+
+        GetRequiredPropertyValue(mapOptionsPayload!, "PixelRatioMode").Should().Be("browserDefault");
+        GetPropertyValue(mapOptionsPayload!, "PixelRatio").Should().BeNull();
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_send_rounded_pixel_ratio_mode_when_initializing_map(CancellationToken cancellationToken)
+    {
+        // arrange & act
+        Render<SgbMap>(parameters =>
+            parameters.Add(
+                p => p.MapOptions,
+                new MapOptions(new Coordinate(49.61, 6.13), PixelRatioMode: MapPixelRatioMode.RoundedUpDevicePixelRatio)
+            )
+        );
+
+        // assert
+        var invocation = JSInterop.Invocations[CreateMapIdentifier].Single();
+        var mapOptionsPayload = invocation.Arguments[3];
+
+        GetRequiredPropertyValue(mapOptionsPayload!, "PixelRatioMode").Should().Be("roundedUpDevicePixelRatio");
+        GetPropertyValue(mapOptionsPayload!, "PixelRatio").Should().BeNull();
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
+    public void Should_send_explicit_pixel_ratio_when_initializing_map(CancellationToken cancellationToken)
+    {
+        // arrange & act
+        Render<SgbMap>(parameters =>
+            parameters.Add(p => p.MapOptions, new MapOptions(new Coordinate(49.61, 6.13), PixelRatio: 1.5))
+        );
+
+        // assert
+        var invocation = JSInterop.Invocations[CreateMapIdentifier].Single();
+        var mapOptionsPayload = invocation.Arguments[3];
+
+        GetRequiredPropertyValue(mapOptionsPayload!, "PixelRatioMode").Should().Be("browserDefault");
+        GetRequiredPropertyValue(mapOptionsPayload!, "PixelRatio").Should().Be(1.5);
+    }
+
+    [Test, Timeout(TestTimeoutMs)]
     public void Should_send_referrer_policies_when_initializing_map(CancellationToken cancellationToken)
     {
         // arrange & act
@@ -359,5 +408,13 @@ public class MapJsInteropPayloadTests : BunitContext
         var value = property!.GetValue(source);
         value.Should().NotBeNull($"property {propertyName} should have a value");
         return value!;
+    }
+
+    private static object? GetPropertyValue(object source, string propertyName)
+    {
+        var property = source.GetType().GetProperty(propertyName);
+        property.Should().NotBeNull($"property {propertyName} should exist on {source.GetType().Name}");
+
+        return property!.GetValue(source);
     }
 }

--- a/src/Spillgebees.Blazor.Map.Tests/Models/MapOptionsTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Models/MapOptionsTests.cs
@@ -1,0 +1,60 @@
+using AwesomeAssertions;
+using Spillgebees.Blazor.Map.Models;
+
+namespace Spillgebees.Blazor.Map.Tests.Models;
+
+public class MapOptionsTests
+{
+    [Test]
+    public void Should_default_to_browser_pixel_ratio()
+    {
+        // arrange & act
+        var options = MapOptions.Default;
+
+        // assert
+        options.PixelRatioMode.Should().Be(MapPixelRatioMode.BrowserDefault);
+        options.PixelRatio.Should().BeNull();
+    }
+
+    [Test]
+    [Arguments(double.NaN)]
+    [Arguments(double.PositiveInfinity)]
+    [Arguments(double.NegativeInfinity)]
+    [Arguments(0d)]
+    [Arguments(-1d)]
+    public void Should_reject_non_finite_or_non_positive_pixel_ratio(double pixelRatio)
+    {
+        // arrange
+
+        // act
+        var act = () => _ = new MapOptions(new Coordinate(0, 0), PixelRatio: pixelRatio);
+
+        // assert
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("pixelRatio");
+    }
+
+    [Test]
+    public void Should_accept_positive_finite_pixel_ratio()
+    {
+        // arrange
+
+        // act
+        var options = new MapOptions(new Coordinate(0, 0), PixelRatio: 1.5);
+
+        // assert
+        options.PixelRatio.Should().Be(1.5);
+    }
+
+    [Test]
+    public void Should_reject_invalid_pixel_ratio_when_using_with_expression()
+    {
+        // arrange
+        var options = MapOptions.Default;
+
+        // act
+        var act = () => _ = options with { PixelRatio = 0 };
+
+        // assert
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("pixelRatio");
+    }
+}

--- a/src/Spillgebees.Blazor.Map.Tests/PublicApiCleanupTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/PublicApiCleanupTests.cs
@@ -157,6 +157,7 @@ public class PublicApiCleanupTests
             "Spillgebees.Blazor.Map.Models.MapBounds",
             "Spillgebees.Blazor.Map.Models.MapImage",
             "Spillgebees.Blazor.Map.Models.MapOptions",
+            "Spillgebees.Blazor.Map.Models.MapPixelRatioMode",
             "Spillgebees.Blazor.Map.Models.MapProjection",
             "Spillgebees.Blazor.Map.Models.MapStyle",
             "Spillgebees.Blazor.Map.Models.MapStyle+OpenFreeMap",
@@ -388,6 +389,21 @@ public class PublicApiCleanupTests
         zoomType.Should().Be(typeof(double));
         minZoomType.Should().Be(typeof(double?));
         maxZoomType.Should().Be(typeof(double?));
+    }
+
+    [Test]
+    public void Should_expose_pixel_ratio_option_types()
+    {
+        // arrange
+        var mapOptionsType = typeof(MapOptions);
+
+        // act
+        var pixelRatioModeType = mapOptionsType.GetProperty(nameof(MapOptions.PixelRatioMode))?.PropertyType;
+        var pixelRatioType = mapOptionsType.GetProperty(nameof(MapOptions.PixelRatio))?.PropertyType;
+
+        // assert
+        pixelRatioModeType.Should().Be(typeof(MapPixelRatioMode));
+        pixelRatioType.Should().Be(typeof(double?));
     }
 
     [Test]

--- a/src/Spillgebees.Blazor.Map.Tests/Samples/PixelRatioExampleTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Samples/PixelRatioExampleTests.cs
@@ -1,0 +1,82 @@
+using AwesomeAssertions;
+using Spillgebees.Blazor.Map.Components;
+using Spillgebees.Blazor.Map.Docs.Samples;
+using Spillgebees.Blazor.Map.Models;
+using Spillgebees.Blazor.Map.Models.Controls;
+
+namespace Spillgebees.Blazor.Map.Tests.Samples;
+
+public class PixelRatioExampleTests : BunitContext
+{
+    public PixelRatioExampleTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<double>("SpillgebeesDocs.getDevicePixelRatio").SetResult(1.25);
+    }
+
+    [Test]
+    public void Should_render_one_map_with_browser_default_selected()
+    {
+        // arrange & act
+        var cut = Render<PixelRatioExample>();
+
+        // assert
+        cut.FindComponents<SgbMap>().Should().HaveCount(1);
+        cut.FindComponents<MapCustomControl>().Should().HaveCount(1);
+        cut.Find(".docs-pixel-ratio-control").TextContent.Should().Contain("1.25x");
+        cut.Find(".docs-pixel-ratio-control").TextContent.Should().Contain("2x");
+        cut.Find("button.active").TextContent.Should().Be("Browser default");
+
+        var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;
+        mapOptions.PixelRatioMode.Should().Be(MapPixelRatioMode.BrowserDefault);
+        mapOptions.PixelRatio.Should().BeNull();
+    }
+
+    [Test]
+    public void Should_switch_to_rounded_device_pixel_ratio()
+    {
+        // arrange
+        var cut = Render<PixelRatioExample>();
+
+        // act
+        cut.FindAll("button.sample-btn").Single(button => button.TextContent.Contains("Rounded DPR")).Click();
+
+        // assert
+        var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;
+        mapOptions.PixelRatioMode.Should().Be(MapPixelRatioMode.RoundedUpDevicePixelRatio);
+        mapOptions.PixelRatio.Should().BeNull();
+        cut.Find(".docs-pixel-ratio-control").TextContent.Should().Contain("2x");
+    }
+
+    [Test]
+    public void Should_switch_to_explicit_pixel_ratio()
+    {
+        // arrange
+        var cut = Render<PixelRatioExample>();
+
+        // act
+        cut.FindAll("button.sample-btn")[2].Click();
+
+        // assert
+        var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;
+        mapOptions.PixelRatio.Should().Be(1.25);
+        cut.Find(".docs-pixel-ratio-control").TextContent.Should().Contain("1.25x");
+    }
+
+    [Test]
+    public void Should_switch_back_to_browser_default()
+    {
+        // arrange
+        var cut = Render<PixelRatioExample>();
+
+        // act
+        cut.FindAll("button.sample-btn").Single(button => button.TextContent.Contains("Rounded DPR")).Click();
+        cut.FindAll("button.sample-btn").Single(button => button.TextContent.Contains("Browser default")).Click();
+
+        // assert
+        var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;
+        mapOptions.PixelRatioMode.Should().Be(MapPixelRatioMode.BrowserDefault);
+        mapOptions.PixelRatio.Should().BeNull();
+        cut.Find(".docs-pixel-ratio-control").TextContent.Should().Contain("1.25x");
+    }
+}

--- a/src/Spillgebees.Blazor.Map.Tests/Samples/PixelRatioExampleTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Samples/PixelRatioExampleTests.cs
@@ -39,7 +39,7 @@ public class PixelRatioExampleTests : BunitContext
         var cut = Render<PixelRatioExample>();
 
         // act
-        cut.FindAll("button.sample-btn").Single(button => button.TextContent.Contains("Rounded DPR")).Click();
+        cut.Find("button[data-test='pixel-ratio-rounded-dpr']").Click();
 
         // assert
         var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;
@@ -55,7 +55,7 @@ public class PixelRatioExampleTests : BunitContext
         var cut = Render<PixelRatioExample>();
 
         // act
-        cut.FindAll("button.sample-btn")[2].Click();
+        cut.Find("button[data-test='pixel-ratio-explicit']").Click();
 
         // assert
         var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;
@@ -70,8 +70,8 @@ public class PixelRatioExampleTests : BunitContext
         var cut = Render<PixelRatioExample>();
 
         // act
-        cut.FindAll("button.sample-btn").Single(button => button.TextContent.Contains("Rounded DPR")).Click();
-        cut.FindAll("button.sample-btn").Single(button => button.TextContent.Contains("Browser default")).Click();
+        cut.Find("button[data-test='pixel-ratio-rounded-dpr']").Click();
+        cut.Find("button[data-test='pixel-ratio-browser-default']").Click();
 
         // assert
         var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;

--- a/src/Spillgebees.Blazor.Map.Tests/Samples/PixelRatioExampleTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Samples/PixelRatioExampleTests.cs
@@ -25,7 +25,7 @@ public class PixelRatioExampleTests : BunitContext
         cut.FindComponents<MapCustomControl>().Should().HaveCount(1);
         cut.Find(".docs-pixel-ratio-control").TextContent.Should().Contain("1.25x");
         cut.Find(".docs-pixel-ratio-control").TextContent.Should().Contain("2x");
-        cut.Find("button.active").TextContent.Should().Be("Browser default");
+        cut.Find("button.active").TextContent.Should().Contain("Browser default");
 
         var mapOptions = cut.FindComponent<SgbMap>().Instance.MapOptions;
         mapOptions.PixelRatioMode.Should().Be(MapPixelRatioMode.BrowserDefault);

--- a/src/Spillgebees.Blazor.Map/Interop/MapJs.cs
+++ b/src/Spillgebees.Blazor.Map/Interop/MapJs.cs
@@ -404,7 +404,11 @@ internal static class MapJs
             {
                 MapPixelRatioMode.BrowserDefault => "browserDefault",
                 MapPixelRatioMode.RoundedUpDevicePixelRatio => "roundedUpDevicePixelRatio",
-                _ => "browserDefault",
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(mapOptions),
+                    mapOptions.PixelRatioMode,
+                    $"Unsupported map pixel ratio mode '{mapOptions.PixelRatioMode}'."
+                ),
             },
             mapOptions.PixelRatio,
         };

--- a/src/Spillgebees.Blazor.Map/Interop/MapJs.cs
+++ b/src/Spillgebees.Blazor.Map/Interop/MapJs.cs
@@ -400,6 +400,13 @@ internal static class MapJs
             mapOptions.Interactive,
             mapOptions.CooperativeGestures,
             WebFonts = mapOptions.WebFonts?.ToArray(),
+            PixelRatioMode = mapOptions.PixelRatioMode switch
+            {
+                MapPixelRatioMode.BrowserDefault => "browserDefault",
+                MapPixelRatioMode.RoundedUpDevicePixelRatio => "roundedUpDevicePixelRatio",
+                _ => "browserDefault",
+            },
+            mapOptions.PixelRatio,
         };
 
     private static object ToJsModel(MapControl control) =>

--- a/src/Spillgebees.Blazor.Map/Models/MapOptions.cs
+++ b/src/Spillgebees.Blazor.Map/Models/MapOptions.cs
@@ -44,6 +44,12 @@ namespace Spillgebees.Blazor.Map.Models;
 /// The fonts must also be loaded via CSS <c>@@import</c> or <c>@@font-face</c> in your application.
 /// Once loaded, they can be referenced by name in SymbolLayer's TextFont property.
 /// </param>
+/// <param name="PixelRatioMode">
+/// Controls how the MapLibre canvas pixel ratio is resolved. Default preserves browser behavior.
+/// </param>
+/// <param name="PixelRatio">
+/// Explicit MapLibre canvas pixel ratio override. When set, this takes precedence over <see cref="PixelRatioMode"/>.
+/// </param>
 public record MapOptions(
     Coordinate Center,
     double Zoom = 0,
@@ -61,11 +67,34 @@ public record MapOptions(
     MapBounds? MaxBounds = null,
     bool Interactive = true,
     bool CooperativeGestures = false,
-    IReadOnlyList<string>? WebFonts = null
+    IReadOnlyList<string>? WebFonts = null,
+    MapPixelRatioMode PixelRatioMode = MapPixelRatioMode.BrowserDefault,
+    double? PixelRatio = null
 )
 {
+    private double? _pixelRatio = ValidatePixelRatio(PixelRatio);
+
+    /// <summary>
+    /// Explicit MapLibre canvas pixel ratio override. When set, this takes precedence over <see cref="PixelRatioMode"/>.
+    /// </summary>
+    public double? PixelRatio
+    {
+        get => _pixelRatio;
+        init => _pixelRatio = ValidatePixelRatio(value);
+    }
+
     /// <summary>
     /// Default map options centered at (0, 0) with zoom level 0.
     /// </summary>
     public static MapOptions Default => new(new Coordinate(0, 0));
+
+    private static double? ValidatePixelRatio(double? pixelRatio)
+    {
+        if (pixelRatio is <= 0 || (pixelRatio.HasValue && !double.IsFinite(pixelRatio.Value)))
+        {
+            throw new ArgumentOutOfRangeException(nameof(pixelRatio), "Pixel ratio must be greater than zero.");
+        }
+
+        return pixelRatio;
+    }
 }

--- a/src/Spillgebees.Blazor.Map/Models/MapPixelRatioMode.cs
+++ b/src/Spillgebees.Blazor.Map/Models/MapPixelRatioMode.cs
@@ -1,0 +1,17 @@
+namespace Spillgebees.Blazor.Map.Models;
+
+/// <summary>
+/// Controls how the MapLibre canvas pixel ratio is resolved for a map instance.
+/// </summary>
+public enum MapPixelRatioMode
+{
+    /// <summary>
+    /// Preserve MapLibre's browser default behavior.
+    /// </summary>
+    BrowserDefault,
+
+    /// <summary>
+    /// Use the next whole-number device pixel ratio, with a minimum of 1.
+    /// </summary>
+    RoundedUpDevicePixelRatio,
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pixel ratio configuration options for maps with `BrowserDefault` and `RoundedUpDevicePixelRatio` modes for improved label sharpness and rendering performance.
  * Support for explicit pixel ratio value overrides.

* **Documentation**
  * Added pixel ratio documentation and interactive example demonstrating mode selection and pixel ratio control.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spillgebees/Blazor.Map/pull/111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->