### PR TITLE
📝  upgrade docs SDK

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="Spillgebees.Blazor.Docs.Sdk" Version="0.7.0" />
+    <PackageVersion Include="Spillgebees.Blazor.Docs.Sdk" Version="0.8.0" />
     <PackageVersion Include="TUnit.Core" Version="1.43.41" />
     <PackageVersion Include="TUnit.Engine" Version="1.43.41" />
   </ItemGroup>

--- a/src/Spillgebees.Blazor.Map.Docs/Layout/MainLayout.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Layout/MainLayout.razor
@@ -1,5 +1,4 @@
 @inherits LayoutComponentBase
-@using System.Text.Json
 
 <DocSite ProjectName="Spillgebees.Blazor.Map"
          LogoEmoji="🗺️"
@@ -19,21 +18,6 @@
             new NavPage("SgbMap", "components/sgb-map"),
             new NavPage("Tracked Entity Layers", "components/tracked-entity-layer"),
         ]),
-        new("API Reference", LoadApiReferenceNav()),
+        new("API Reference", ApiReferenceNav.Generate<SgbMap>()),
     ];
-
-    /// The SDK's ApiReferenceNav.Generate looks for the manifest in typeof(T).Assembly,
-    /// but the manifest is embedded in the Docs assembly, not the library assembly.
-    /// Load it manually from the Docs assembly as a workaround.
-    private static IReadOnlyList<NavPage> LoadApiReferenceNav()
-    {
-        var docsAssembly = typeof(MainLayout).Assembly;
-        var resourceName = $"ApiManifest:Spillgebees.Blazor.Map";
-
-        using var stream = docsAssembly.GetManifestResourceStream(resourceName);
-        if (stream is null) return [];
-
-        var manifest = JsonSerializer.Deserialize<ApiManifest>(stream);
-        return manifest is null ? [] : ApiReferenceNav.FromManifest(manifest);
-    }
 }

--- a/src/Spillgebees.Blazor.Map.Docs/Pages/Api/ApiReferencePage.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Pages/Api/ApiReferencePage.razor
@@ -1,7 +1,6 @@
-@page "/api/{TypeName}"
-@using System.Text.Json
+@page "/api/{TypeSlug}"
 
-<PageTitle>API Reference | @ShortName</PageTitle>
+<PageTitle>API Reference | @TypeSlug</PageTitle>
 
 @if (_typeInfo is not null)
 {
@@ -10,35 +9,17 @@
 else
 {
     <h1>Type not found</h1>
-    <p>Could not resolve <code>@TypeName</code>.</p>
+    <p>No API documentation available for <code>@TypeSlug</code>.</p>
 }
 
 @code {
     [Parameter]
-    public string TypeName { get; set; } = "";
-
-    private string ShortName => TypeName.Split('.').Last();
+    public string TypeSlug { get; set; } = "";
 
     private ApiTypeInfo? _typeInfo;
 
-    private static readonly ApiManifest? _manifest = LoadManifest();
-
     protected override void OnParametersSet()
     {
-        _typeInfo = _manifest?.Types.FirstOrDefault(t => t.FullName == TypeName);
-    }
-
-    /// The SDK's ApiDoc looks for the manifest in Type.Assembly,
-    /// but the manifest is embedded in the Docs assembly, not the library assembly.
-    /// Load it manually from the Docs assembly as a workaround.
-    private static ApiManifest? LoadManifest()
-    {
-        var docsAssembly = typeof(ApiReferencePage).Assembly;
-        var resourceName = "ApiManifest:Spillgebees.Blazor.Map";
-
-        using var stream = docsAssembly.GetManifestResourceStream(resourceName);
-        if (stream is null) return null;
-
-        return JsonSerializer.Deserialize<ApiManifest>(stream);
+        _typeInfo = ApiReferenceNav.FindType<SgbMap>(TypeSlug);
     }
 }

--- a/src/Spillgebees.Blazor.Map.Docs/Pages/Components/SgbMapPage.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Pages/Components/SgbMapPage.razor
@@ -3,7 +3,7 @@
 <PageTitle>SgbMap | Spillgebees.Blazor.Map</PageTitle>
 
 <Breadcrumb Section="components" PageName="SgbMap"
-            ApiReferenceUrl="api/Spillgebees.Blazor.Map.Components.SgbMap"
+            ApiReferenceUrl="api/SgbMap"
             SourceUrl="https://github.com/Spillgebees/Blazor.Map/blob/main/src/Spillgebees.Blazor.Map/Components/SgbMap.razor" />
 <OnThisPage />
 

--- a/src/Spillgebees.Blazor.Map.Docs/Pages/Components/TrackedEntityLayerPage.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Pages/Components/TrackedEntityLayerPage.razor
@@ -3,7 +3,7 @@
 <PageTitle>TrackedEntityLayer | Spillgebees.Blazor.Map</PageTitle>
 
 <Breadcrumb Section="components" PageName="TrackedEntityLayer"
-            ApiReferenceUrl="api/Spillgebees.Blazor.Map.Components.Layers.TrackedEntityLayer-1"
+            ApiReferenceUrl="api/TrackedEntityLayer-1"
             SourceUrl="https://github.com/Spillgebees/Blazor.Map/blob/main/src/Spillgebees.Blazor.Map/Components/Layers/TrackedEntityLayer.razor" />
 <OnThisPage />
 
@@ -29,6 +29,6 @@
 </ul>
 
 <ExampleView TComponent="TrainTrackingExample"
-             AdditionalSources="@(new[] { typeof(TrainTrackingPresentation), typeof(TrainSampleSimulation) })">
+             AdditionalSources="@([typeof(TrainTrackingPresentation), typeof(TrainSampleSimulation)])">
     <TrainTrackingExample />
 </ExampleView>

--- a/src/Spillgebees.Blazor.Map.Docs/Spillgebees.Blazor.Map.Docs.csproj
+++ b/src/Spillgebees.Blazor.Map.Docs/Spillgebees.Blazor.Map.Docs.csproj
@@ -8,6 +8,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Spillgebees.Blazor.Map\Spillgebees.Blazor.Map.csproj" />
+    <ProjectReference
+      Include="..\Spillgebees.Blazor.Map\Spillgebees.Blazor.Map.csproj"
+      DocsApi="true"
+    />
   </ItemGroup>
 </Project>

--- a/src/Spillgebees.Blazor.Map.Docs/_Imports.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/_Imports.razor
@@ -4,9 +4,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
-@using Spillgebees.Blazor.Docs.Sdk.Components
-@using Spillgebees.Blazor.Docs.Sdk.Navigation
-@using Spillgebees.Blazor.Docs.Sdk.Build
+@using Spillgebees.Blazor.Docs.Sdk
 @using Spillgebees.Blazor.Map.Docs
 @using Spillgebees.Blazor.Map.Docs.Layout
 @using Spillgebees.Blazor.Map.Docs.Samples


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `Spillgebees.Blazor.Docs.Sdk` dependency to version 0.8.0.

* **Bug Fixes**
  * Simplified API reference routing to use shortened type slugs (e.g., `/api/SgbMap`) instead of fully-qualified names for improved URL clarity and usability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spillgebees/Blazor.Map/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->