### PR TITLE
Revert "Enable toggleable style overlays via MapOverlays and preserve composed glyph configuration"

### DIFF
--- a/src/Spillgebees.Blazor.Map.Docs/Pages/Components/ControlsPage.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Pages/Components/ControlsPage.razor
@@ -65,10 +65,6 @@
 <p><code>LayerMapControl</code> renders <code>SgbMap.LayerVisibility</code> groups. Use <code>GroupIds</code> to choose and order a subset.</p>
 <CodeBlock Language="razor" Files="@_layerExamples" />
 
-<h2 id="overlay_map_controls">// overlay_map_controls</h2>
-<p><code>OverlayMapControl</code> renders toggles for entries declared in <code>MapOverlays</code>. Programmatic overlay methods on <code>SgbMap</code>/<code>BaseMap</code> use the same visibility behavior as the control UI.</p>
-<CodeBlock Language="razor" Files="@_overlayExamples" />
-
 <h2 id="legend_map_controls">// legend_map_controls</h2>
 <p><code>LegendMapControl</code> explains visual symbols. Use structured symbols for common swatches, lines, dashed lines, and circles; use templates only for bespoke legends.</p>
 <CodeBlock Language="razor" Files="@_legendExamples" />
@@ -200,31 +196,6 @@
                     <LayerMapControl Id="layers" InitiallyOpen="true" />
                 </MapControls>
             </SgbMap>
-            """,
-    };
-
-    private static readonly Dictionary<string, string> _overlayExamples = new()
-    {
-        ["OverlayMapControl.razor"] = """
-            <SgbMap @ref="_map">
-                <MapControls>
-                    <OverlayMapControl Id="overlays" />
-                </MapControls>
-
-                <MapOverlays>
-                    <MapOverlay Id="lux-railway" Label="Lux railway infrastructure">
-                        <StyleOverlay Style='@MapStyle.FromUrl("traintracking/style.json").WithId("lux-railway")' />
-                        <MapOverlayPart Id="tracks" Label="Tracks" LayerIds='@(new[] { "railway-line-rail" })' />
-                    </MapOverlay>
-                </MapOverlays>
-            </SgbMap>
-
-            <button @onclick='() => _map?.ToggleOverlay("lux-railway")'>Toggle overlay</button>
-            <button @onclick='() => _map?.ToggleOverlayPart("lux-railway", "tracks")'>Toggle part</button>
-
-            @code {
-                private SgbMap? _map;
-            }
             """,
     };
 

--- a/src/Spillgebees.Blazor.Map.Tests/Components/OverlayMapControlTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Components/OverlayMapControlTests.cs
@@ -90,101 +90,26 @@ public class OverlayMapControlTests : BunitContext
         latestOverlay.Parts!.Should().Contain(part => part.PartId == "tracks" && part.Visible == true);
     }
 
-    [Test, Timeout(TestTimeoutMs)]
-    public async Task Should_toggle_overlay_programmatically_without_overlay_map_control(
-        CancellationToken cancellationToken
-    )
-    {
-        var cut = RenderOverlayMap(includeParts: false, includeOverlayControl: false);
-        await cut.Instance.OnMapInitializedAsync();
-        var initialBatchCount = JSInterop.Invocations[ApplySceneMutationsIdentifier].Count;
-
-        cut.Instance.ToggleOverlay("lux-railway");
-
-        cut.WaitForAssertion(() =>
-            JSInterop.Invocations[ApplySceneMutationsIdentifier].Count.Should().BeGreaterThan(initialBatchCount)
-        );
-        GetLatestSceneMutationBatch()
-            .Mutations.Should()
-            .ContainSingle(mutation =>
-                mutation.Kind == "setOverlay" && mutation.OverlayId == "lux-railway" && mutation.Visible == false
-            );
-    }
-
-    [Test, Timeout(TestTimeoutMs)]
-    public async Task Should_toggle_overlay_part_programmatically_and_preserve_part_state_without_overlay_map_control(
-        CancellationToken cancellationToken
-    )
-    {
-        var cut = RenderOverlayMap(includeParts: true, includeOverlayControl: false);
-        await cut.Instance.OnMapInitializedAsync();
-        var initialMutationCount = GetSceneMutations().Count;
-
-        cut.Instance.ToggleOverlayPart("lux-railway", "tracks");
-        cut.Instance.ToggleOverlay("lux-railway");
-        cut.Instance.ToggleOverlay("lux-railway");
-
-        cut.WaitForAssertion(() => GetSceneMutations().Count.Should().BeGreaterThan(initialMutationCount));
-
-        var latestOverlay = GetSceneMutations()
-            .Skip(initialMutationCount)
-            .Last(mutation => mutation.Kind == "setOverlay" && mutation.OverlayId == "lux-railway");
-
-        latestOverlay.Visible.Should().BeTrue();
-        latestOverlay.Parts!.Should().Contain(part => part.PartId == "tracks" && part.Visible == false);
-        latestOverlay.Parts!.Should().Contain(part => part.PartId == "lifecycle" && part.Visible == false);
-    }
-
-    [Test]
-    public void Should_throw_for_unknown_programmatic_overlay_and_part_ids()
-    {
-        var cut = RenderOverlayMap(includeParts: true, includeOverlayControl: false);
-
-        var missingOverlay = () => cut.Instance.ToggleOverlay("missing-overlay");
-        var missingPart = () => cut.Instance.ToggleOverlayPart("lux-railway", "missing-part");
-
-        missingOverlay.Should().Throw<KeyNotFoundException>().WithMessage("Overlay 'missing-overlay' was not found.");
-        missingPart
-            .Should()
-            .Throw<KeyNotFoundException>()
-            .WithMessage("Overlay part 'missing-part' was not found in overlay 'lux-railway'.");
-    }
-
-    [Test]
-    public void Should_expose_overlay_items_programmatically_without_overlay_map_control()
-    {
-        var cut = RenderOverlayMap(includeParts: true, includeOverlayControl: false);
-
-        var items = cut.Instance.GetOverlayItems();
-
-        items.Should().ContainSingle();
-        items[0].Id.Should().Be("lux-railway");
-        items[0].Parts.Select(part => part.Id).Should().BeEquivalentTo(["tracks", "lifecycle"]);
-    }
-
-    private IRenderedComponent<SgbMap> RenderOverlayMap(bool includeParts, bool includeOverlayControl = true) =>
+    private IRenderedComponent<SgbMap> RenderOverlayMap(bool includeParts) =>
         Render<SgbMap>(parameters =>
             parameters.AddChildContent(
                 (RenderFragment)(
                     builder =>
                     {
-                        if (includeOverlayControl)
-                        {
-                            builder.OpenComponent<MapControls>(0);
-                            builder.AddAttribute(
-                                1,
-                                nameof(MapControls.ChildContent),
-                                (RenderFragment)(
-                                    controls =>
-                                    {
-                                        controls.OpenComponent<OverlayMapControl>(0);
-                                        controls.AddAttribute(1, nameof(OverlayMapControl.Id), "overlays");
-                                        controls.CloseComponent();
-                                    }
-                                )
-                            );
-                            builder.CloseComponent();
-                        }
+                        builder.OpenComponent<MapControls>(0);
+                        builder.AddAttribute(
+                            1,
+                            nameof(MapControls.ChildContent),
+                            (RenderFragment)(
+                                controls =>
+                                {
+                                    controls.OpenComponent<OverlayMapControl>(0);
+                                    controls.AddAttribute(1, nameof(OverlayMapControl.Id), "overlays");
+                                    controls.CloseComponent();
+                                }
+                            )
+                        );
+                        builder.CloseComponent();
 
                         builder.OpenComponent<MapOverlays>(2);
                         builder.AddAttribute(

--- a/src/Spillgebees.Blazor.Map/Components/BaseMap.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/BaseMap.razor.cs
@@ -909,10 +909,7 @@ public abstract partial class BaseMap : ComponentBase, IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// Gets the currently registered overlays and their visible state.
-    /// </summary>
-    public IReadOnlyList<MapOverlayItem> GetOverlayItems() =>
+    internal IReadOnlyList<MapOverlayItem> GetOverlayItems() =>
         _registeredOverlays
             .Values.OrderBy(overlay => overlay.Order)
             .ThenBy(overlay => overlay.Id, StringComparer.Ordinal)
@@ -936,13 +933,7 @@ public abstract partial class BaseMap : ComponentBase, IAsyncDisposable
             ))
             .ToArray();
 
-    /// <summary>
-    /// Sets the visibility of the specified overlay.
-    /// </summary>
-    /// <param name="overlayId">Overlay id.</param>
-    /// <param name="visible">Target visibility state.</param>
-    /// <exception cref="KeyNotFoundException">Thrown when the overlay id is unknown.</exception>
-    public void SetOverlayVisible(string overlayId, bool visible)
+    internal void SetOverlayVisible(string overlayId, bool visible)
     {
         if (!_registeredOverlays.TryGetValue(overlayId, out var overlay))
         {
@@ -958,31 +949,7 @@ public abstract partial class BaseMap : ComponentBase, IAsyncDisposable
         RequestOverlaySync(new MapOverlayChangedEventArgs(overlayId));
     }
 
-    /// <summary>
-    /// Toggles visibility of the specified overlay.
-    /// </summary>
-    /// <param name="overlayId">Overlay id.</param>
-    /// <exception cref="KeyNotFoundException">Thrown when the overlay id is unknown.</exception>
-    public void ToggleOverlay(string overlayId)
-    {
-        if (!_registeredOverlays.TryGetValue(overlayId, out var overlay))
-        {
-            throw new KeyNotFoundException($"Overlay '{overlayId}' was not found.");
-        }
-
-        SetOverlayVisible(overlayId, !overlay.Visible);
-    }
-
-    /// <summary>
-    /// Sets the visibility of the specified overlay part.
-    /// </summary>
-    /// <param name="overlayId">Overlay id.</param>
-    /// <param name="partId">Part id within the overlay.</param>
-    /// <param name="visible">Target visibility state.</param>
-    /// <exception cref="KeyNotFoundException">
-    /// Thrown when the overlay id or part id is unknown.
-    /// </exception>
-    public void SetOverlayPartVisible(string overlayId, string partId, bool visible)
+    internal void SetOverlayPartVisible(string overlayId, string partId, bool visible)
     {
         if (!_registeredOverlays.TryGetValue(overlayId, out var overlay))
         {
@@ -1001,29 +968,6 @@ public abstract partial class BaseMap : ComponentBase, IAsyncDisposable
 
         part.Visible = visible;
         RequestOverlaySync(new MapOverlayChangedEventArgs(overlayId, partId));
-    }
-
-    /// <summary>
-    /// Toggles visibility of the specified overlay part.
-    /// </summary>
-    /// <param name="overlayId">Overlay id.</param>
-    /// <param name="partId">Part id within the overlay.</param>
-    /// <exception cref="KeyNotFoundException">
-    /// Thrown when the overlay id or part id is unknown.
-    /// </exception>
-    public void ToggleOverlayPart(string overlayId, string partId)
-    {
-        if (!_registeredOverlays.TryGetValue(overlayId, out var overlay))
-        {
-            throw new KeyNotFoundException($"Overlay '{overlayId}' was not found.");
-        }
-
-        if (!overlay.Parts.TryGetValue(partId, out var part))
-        {
-            throw new KeyNotFoundException($"Overlay part '{partId}' was not found in overlay '{overlayId}'.");
-        }
-
-        SetOverlayPartVisible(overlayId, partId, !part.Visible);
     }
 
     private RegisteredOverlayDefinition GetOrCreateOverlay(string overlayId)

--- a/src/Spillgebees.Blazor.Map/Components/OverlayMapControl.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/OverlayMapControl.razor.cs
@@ -109,10 +109,11 @@ public partial class OverlayMapControl : ComponentBase, IDisposable
         MapOverlayPartItem part
     ) => new(overlay, part, visible => SetPartVisibleAsync(overlay.Id, part.Id, visible));
 
-    private Task ToggleOverlayAsync(MapOverlayItem overlay, ChangeEventArgs _) => ToggleOverlayAsync(overlay.Id);
+    private Task ToggleOverlayAsync(MapOverlayItem overlay, ChangeEventArgs args) =>
+        SetOverlayVisibleAsync(overlay.Id, ResolveToggleValue(args));
 
-    private Task TogglePartAsync(MapOverlayItem overlay, MapOverlayPartItem part, ChangeEventArgs _) =>
-        TogglePartAsync(overlay.Id, part.Id);
+    private Task TogglePartAsync(MapOverlayItem overlay, MapOverlayPartItem part, ChangeEventArgs args) =>
+        SetPartVisibleAsync(overlay.Id, part.Id, ResolveToggleValue(args));
 
     private Task SetOverlayVisibleAsync(string overlayId, bool visible)
     {
@@ -126,20 +127,16 @@ public partial class OverlayMapControl : ComponentBase, IDisposable
         return Task.CompletedTask;
     }
 
-    private Task ToggleOverlayAsync(string overlayId)
-    {
-        Map!.ToggleOverlay(overlayId);
-        return Task.CompletedTask;
-    }
-
-    private Task TogglePartAsync(string overlayId, string partId)
-    {
-        Map!.ToggleOverlayPart(overlayId, partId);
-        return Task.CompletedTask;
-    }
-
     private void HandleOverlayChanged(object? sender, MapOverlayChangedEventArgs args) =>
         _ = InvokeAsync(StateHasChanged);
+
+    private static bool ResolveToggleValue(ChangeEventArgs args) =>
+        args.Value switch
+        {
+            bool boolValue => boolValue,
+            string stringValue when bool.TryParse(stringValue, out var parsed) => parsed,
+            _ => throw new InvalidOperationException("Overlay toggle expected a bool or parseable string value."),
+        };
 
     private static RenderFragment RenderLegendSymbol(MapLegendSymbol? symbol) =>
         builder =>


### PR DESCRIPTION
Reverts Spillgebees/Blazor.Map#117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed public methods for programmatically toggling overlays and overlay parts. Users must now interact with overlay visibility through the overlay map control UI instead of direct API calls.

* **Documentation**
  * Removed overlay map control documentation section from guides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spillgebees/Blazor.Map/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->