### PR TITLE
✨ add zizmor workflow security analysis

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: 🔎 checking for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 📦 setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,19 @@
+name: Workflow security analysis
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  zizmor:
+    name: zizmor
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    uses: Spillgebees/admin/.github/workflows/zizmor.yml@a71d815a53f77f9cabca802b4bd9b69fe2fcd96e # main


### PR DESCRIPTION
## Summary

- Adds a thin caller for the reusable [zizmor](https://docs.zizmor.sh/) workflow from `Spillgebees/admin` (added in Spillgebees/admin#6). zizmor statically analyzes GitHub Actions workflows for security issues (template injection, credential persistence, unpinned actions, excessive permissions, …). Findings are uploaded as SARIF and appear under **Security → Code scanning**.
- Fixes the two [`artipacked`](https://docs.zizmor.sh/audits/#artipacked) findings zizmor reported: the checkout steps in `build-and-test.yml` and `build-test-publish.yml` now set `persist-credentials: false`.

## Baseline after this PR

Local run of zizmor v1.25.2: no warnings; one informational finding remains ([`use-trusted-publishing`](https://docs.zizmor.sh/audits/#use-trusted-publishing) on `publish.yml`), to be addressed separately when migrating to NuGet trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security by disabling credential persistence in checkout steps.
  * Added automated workflow security analysis to the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->