### PR TITLE
⚡  fix pan/zoom performance regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,11 @@ ASP.NET Core package versions are pinned in `src/Directory.Packages.props`.
 - **CSharpier**: formats `.cs`, `.csproj`, `.props`, `.targets`, `.slnx`, `.xml`
 - **Husky.Net**: pre-commit hook runs CSharpier on staged files
 - **Biome**: formats + lints TypeScript (configured in `src/Spillgebees.Blazor.Map.Assets/biome.json`)
+
+## Code style
+
+Soft guidelines (not build-enforced), C# side:
+
+- **Member order**: `[Inject]` → `[CascadingParameter]` → `[Parameter]` first, then everything
+  else public-before-private, with nested types and `DisposeAsync` last. Keep fields/consts at
+  the top of their group. For non-component classes this is just the usual public-before-private.

--- a/src/Spillgebees.Blazor.Map.Assets/tests/browser/perf/freeze-benchmarks.spec.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/tests/browser/perf/freeze-benchmarks.spec.ts
@@ -160,16 +160,70 @@ test.describe("map update benchmarks", () => {
       frameId: ENGINE_VECTOR_FRAME_ID,
       query: { interval: "100" },
     },
+    // Pan smoothness — the everyday "moving around the map" use-case. The NoChanges
+    // pattern rebuilds value-identical feature lists every tick (the idiomatic Blazor
+    // "list recreated on every render" shape), so the only legitimate map work during
+    // the drag-pans is camera rendering. Redundant shape re-uploads show up both as
+    // frame gaps and as a climbing setData counter, so the counter ceiling pins the
+    // coordinator's unchanged-payload skip.
+    {
+      name: "i-pan-circles-rerender-only",
+      route: "/engine-shapes-stress-test",
+      frameId: ENGINE_SHAPES_FRAME_ID,
+      query: { entities: "2000", interval: "100", pattern: "NoChanges", mode: "Circles" },
+      duringMeasure: dragPanAcrossMap,
+      maxCounters: { setData: 2 },
+    },
+    {
+      name: "i-pan-polylines-rerender-only",
+      route: "/engine-shapes-stress-test",
+      frameId: ENGINE_SHAPES_FRAME_ID,
+      query: { entities: "2000", interval: "100", pattern: "NoChanges", mode: "Polylines" },
+      duringMeasure: dragPanAcrossMap,
+      maxCounters: { setData: 2 },
+    },
+    // Pan smoothness with genuinely changing data — the legitimate update cost that
+    // must coexist with camera movement.
+    {
+      name: "i-pan-circles-live-data",
+      route: "/engine-shapes-stress-test",
+      frameId: ENGINE_SHAPES_FRAME_ID,
+      query: { entities: "2000", interval: "100", pattern: "TenPercent", mode: "Circles" },
+      duringMeasure: dragPanAcrossMap,
+    },
   ];
 
   for (const scenario of scenarios) {
     test(scenario.name, async ({ page }, testInfo) => {
       const snapshot = await runStressScenario(page, scenario);
       await reportResults(testInfo, scenario, snapshot);
-      assertBudgets(snapshot);
+      assertBudgets(snapshot, scenario);
     });
   }
 });
+
+/** Out-and-back drag-pans around the feature field, with a settle pause per gesture. */
+async function dragPanAcrossMap(page: Page): Promise<void> {
+  const box = await page.locator(".sgb-map-container canvas").boundingBox();
+  expect(box, "map canvas must be visible for drag pans").not.toBeNull();
+  if (!box) {
+    return;
+  }
+
+  const centerX = box.x + box.width / 2;
+  const centerY = box.y + box.height / 2;
+  for (const direction of [1, -1]) {
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.down();
+    for (let step = 1; step <= 10; step++) {
+      await page.mouse.move(centerX + direction * step * 18, centerY + direction * step * 6, { steps: 2 });
+      await page.waitForTimeout(16);
+    }
+    await page.mouse.up();
+    // let inertia finish so moveend (and the re-render it triggers) lands in-measure
+    await page.waitForTimeout(150);
+  }
+}
 
 async function sweepPointerAcrossMap(page: Page): Promise<void> {
   const box = await page.locator(".sgb-map-container canvas").boundingBox();

--- a/src/Spillgebees.Blazor.Map.Assets/tests/browser/perf/helpers.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/tests/browser/perf/helpers.ts
@@ -50,6 +50,11 @@ export interface StressScenario {
    * something or the scenario is silently measuring an empty map.
    */
   rendersGlFeatures?: boolean;
+  /**
+   * Ceilings on MapLibre call counters during the measure window (e.g.
+   * `{ setData: 2 }` pins a scenario whose data never changes to ~zero re-uploads).
+   */
+  maxCounters?: Record<string, number>;
 }
 
 export const ENGINE_FRAME_ID = "engine-entity-stress-frame";
@@ -134,7 +139,7 @@ export async function reportResults(
   });
 }
 
-export function assertBudgets(snapshot: StressSnapshot): void {
+export function assertBudgets(snapshot: StressSnapshot, scenario?: Pick<StressScenario, "maxCounters">): void {
   if (RECORD_ONLY) {
     return;
   }
@@ -148,6 +153,16 @@ export function assertBudgets(snapshot: StressSnapshot): void {
   expect
     .soft(snapshot.frameGaps.p95, `frame gap p95 must stay under ${BUDGETS.frameGapP95Ms}ms`)
     .toBeLessThan(BUDGETS.frameGapP95Ms);
+
+  // counter ceilings are exact call counts, not timings — no BUDGET_SCALE
+  for (const [counter, ceiling] of Object.entries(scenario?.maxCounters ?? {})) {
+    expect
+      .soft(
+        snapshot.counters[counter] ?? 0,
+        `${counter} calls during the measure window must stay at or under ${ceiling}`,
+      )
+      .toBeLessThanOrEqual(ceiling);
+  }
 }
 
 declare global {

--- a/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineShapesStressTest.razor
+++ b/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineShapesStressTest.razor
@@ -51,6 +51,7 @@
             <select @bind:get="_updatePattern" @bind:set="OnUpdatePatternChanged">
                 <option value="AllFeatures">Update all features</option>
                 <option value="TenPercent">Update 10%</option>
+                <option value="NoChanges">Rebuild without changes</option>
             </select>
         </label>
 
@@ -322,7 +323,14 @@
     }
 
     private static bool ShouldUpdateFeature(int index, int tick, UpdatePattern updatePattern) =>
-        updatePattern != UpdatePattern.TenPercent || index % 10 == tick % 10;
+        updatePattern switch
+        {
+            // value-identical rebuild per tick: the idiomatic "list recreated on every
+            // render" Blazor pattern, where no map work should happen at all
+            UpdatePattern.NoChanges => false,
+            UpdatePattern.TenPercent => index % 10 == tick % 10,
+            _ => true,
+        };
 
     public async ValueTask DisposeAsync()
     {
@@ -345,5 +353,6 @@
     {
         AllFeatures,
         TenPercent,
+        NoChanges,
     }
 }

--- a/src/Spillgebees.Blazor.Map.Tests/Engine/MapFeatureCoordinatorTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Engine/MapFeatureCoordinatorTests.cs
@@ -1,0 +1,146 @@
+using AwesomeAssertions;
+using Microsoft.JSInterop;
+using Spillgebees.Blazor.Map.Engine;
+
+namespace Spillgebees.Blazor.Map.Tests.Engine;
+
+/// <summary>
+/// The shapes flush path runs on every render of the host component, so value-identical
+/// payloads (lists rebuilt per render, e.g. after every moveend) must not cross the
+/// wire: each redundant setSourceData costs a JS-side JSON.parse plus a full MapLibre
+/// source re-tile, which degrades pan smoothness.
+/// </summary>
+public class MapFeatureCoordinatorTests
+{
+    private const string SetSourceDataIdentifier = "Spillgebees.Engine.setSourceData";
+
+    [Test]
+    public async Task Should_not_repush_circles_when_a_rebuilt_list_is_value_identical()
+    {
+        // arrange
+        var (coordinator, js) = await CreateReadyCoordinatorAsync();
+        coordinator.SetCircles("owner", [BuildCircle("c1"), BuildCircle("c2")]);
+        var callsAfterFirstFlush = CountSourceDataCalls(js);
+
+        // act: a fresh list with freshly constructed, value-equal records
+        coordinator.SetCircles("owner", [BuildCircle("c1"), BuildCircle("c2")]);
+
+        // assert
+        callsAfterFirstFlush.Should().Be(1);
+        CountSourceDataCalls(js).Should().Be(1);
+    }
+
+    [Test]
+    public async Task Should_push_circles_when_a_rebuilt_list_actually_changed()
+    {
+        // arrange
+        var (coordinator, js) = await CreateReadyCoordinatorAsync();
+        coordinator.SetCircles("owner", [BuildCircle("c1")]);
+
+        // act
+        coordinator.SetCircles("owner", [BuildCircle("c1", latitude: 49.7)]);
+
+        // assert
+        CountSourceDataCalls(js).Should().Be(2);
+    }
+
+    [Test]
+    public async Task Should_not_repush_polylines_when_a_rebuilt_list_is_value_identical()
+    {
+        // arrange
+        var (coordinator, js) = await CreateReadyCoordinatorAsync();
+        coordinator.SetPolylines("owner", [BuildPolyline("l1")]);
+        var callsAfterFirstFlush = CountSourceDataCalls(js);
+
+        // act
+        coordinator.SetPolylines("owner", [BuildPolyline("l1")]);
+
+        // assert
+        callsAfterFirstFlush.Should().Be(1);
+        CountSourceDataCalls(js).Should().Be(1);
+    }
+
+    [Test]
+    public async Task Should_push_polylines_when_coordinates_changed()
+    {
+        // arrange
+        var (coordinator, js) = await CreateReadyCoordinatorAsync();
+        coordinator.SetPolylines("owner", [BuildPolyline("l1")]);
+
+        // act
+        coordinator.SetPolylines("owner", [BuildPolyline("l1", latitudeOffset: 0.01)]);
+
+        // assert
+        CountSourceDataCalls(js).Should().Be(2);
+    }
+
+    [Test]
+    public async Task Should_sync_recreated_parameter_lists_without_repushing()
+    {
+        // arrange
+        var (coordinator, js) = await CreateReadyCoordinatorAsync();
+        coordinator.SyncParameters(markers: null, circles: [BuildCircle("c1")], polylines: [BuildPolyline("l1")]);
+        var callsAfterFirstSync = CountSourceDataCalls(js);
+
+        // act: every render hands over freshly allocated, value-identical lists
+        coordinator.SyncParameters(markers: null, circles: [BuildCircle("c1")], polylines: [BuildPolyline("l1")]);
+
+        // assert
+        callsAfterFirstSync.Should().Be(2);
+        CountSourceDataCalls(js).Should().Be(2);
+    }
+
+    [Test]
+    public async Task Should_push_the_emptied_collection_when_an_owner_is_removed()
+    {
+        // arrange
+        var (coordinator, js) = await CreateReadyCoordinatorAsync();
+        coordinator.SetCircles("owner", [BuildCircle("c1")]);
+
+        // act
+        coordinator.RemoveOwner("owner");
+
+        // assert: circles flush again (now empty); polylines never had content to flush
+        CountSourceDataCalls(js).Should().Be(2);
+    }
+
+    private static async Task<(MapFeatureCoordinator Coordinator, RecordingJsRuntime Js)> CreateReadyCoordinatorAsync()
+    {
+        var js = new RecordingJsRuntime();
+        var channel = new MapEngineChannel(js);
+        channel.Attach(default);
+        await channel.MarkReadyAsync();
+        return (new MapFeatureCoordinator(channel), js);
+    }
+
+    private static Circle BuildCircle(string id, double latitude = 49.6117, double longitude = 6.1319) =>
+        new(id, new Coordinate(latitude, longitude), Radius: 4, Color: "#2563eb");
+
+    private static Polyline BuildPolyline(string id, double latitudeOffset = 0) =>
+        new(
+            id,
+            [new Coordinate(49.61 + latitudeOffset, 6.13), new Coordinate(49.62 + latitudeOffset, 6.14)],
+            Color: "#0ea5e9",
+            Width: 2
+        );
+
+    private static int CountSourceDataCalls(RecordingJsRuntime js) =>
+        js.Identifiers.Count(identifier => identifier == SetSourceDataIdentifier);
+
+    private sealed class RecordingJsRuntime : IJSRuntime
+    {
+        public List<string> Identifiers { get; } = [];
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            Identifiers.Add(identifier);
+            return ValueTask.FromResult(default(TValue)!);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier,
+            CancellationToken cancellationToken,
+            object?[]? args
+        ) => InvokeAsync<TValue>(identifier, args);
+    }
+}

--- a/src/Spillgebees.Blazor.Map/Engine/MapFeatureCoordinator.cs
+++ b/src/Spillgebees.Blazor.Map/Engine/MapFeatureCoordinator.cs
@@ -20,11 +20,21 @@ internal sealed class MapFeatureCoordinator(MapEngineChannel channel)
     private const string PolylinesSourceId = "sgb-polylines-source";
     private const string PolylinesLayerId = "sgb-polylines-layer";
     private const string ParameterFeaturesOwnerId = "map-parameters";
+    private const string EmptyCollectionJson = """{"type":"FeatureCollection","features":[]}""";
 
     private static readonly JsonSerializerOptions _popupJsonOptions = new(JsonSerializerDefaults.Web);
 
     // reused across flushes — a 2,000-circle collection is ~300 KB of JSON per tick
     private readonly ArrayBufferWriter<byte> _flushBuffer = new(512 * 1024);
+
+    // Last payload flushed per shapes source. Hosts re-render on every UI event
+    // (each moveend/zoomend included) and idiomatic Blazor rebuilds the feature lists
+    // each time, so flushes run constantly with unchanged content — and a redundant
+    // push costs a JS-side JSON.parse plus a full MapLibre source re-tile, which is
+    // exactly what makes panning stutter. Both sources start empty JS-side
+    // (EnsureShapeInfrastructure), hence the empty-collection sentinel.
+    private byte[] _flushedCirclesPayload = Encoding.UTF8.GetBytes(EmptyCollectionJson);
+    private byte[] _flushedPolylinesPayload = Encoding.UTF8.GetBytes(EmptyCollectionJson);
 
     private readonly Dictionary<string, IReadOnlyList<Marker>> _markersByOwner = [];
     private readonly Dictionary<string, IReadOnlyList<Circle>> _circlesByOwner = [];
@@ -147,11 +157,10 @@ internal sealed class MapFeatureCoordinator(MapEngineChannel channel)
         }
 
         _shapeInfrastructureQueued = true;
-        var emptyCollection = """{"type":"FeatureCollection","features":[]}""";
         channel.Queue(
             new SourceAddOp(
                 CirclesSourceId,
-                new JsonObject { ["type"] = "geojson", ["data"] = JsonNode.Parse(emptyCollection) }
+                new JsonObject { ["type"] = "geojson", ["data"] = JsonNode.Parse(EmptyCollectionJson) }
             )
         );
         channel.Queue(
@@ -172,11 +181,7 @@ internal sealed class MapFeatureCoordinator(MapEngineChannel channel)
                             EngineSpec.Expr("get", "strokeColor"),
                             "transparent"
                         ),
-                        ["circle-stroke-width"] = EngineSpec.Expr(
-                            "coalesce",
-                            EngineSpec.Expr("get", "strokeWidth"),
-                            0
-                        ),
+                        ["circle-stroke-width"] = EngineSpec.Expr("coalesce", EngineSpec.Expr("get", "strokeWidth"), 0),
                         ["circle-stroke-opacity"] = EngineSpec.Expr(
                             "coalesce",
                             EngineSpec.Expr("get", "strokeOpacity"),
@@ -189,7 +194,7 @@ internal sealed class MapFeatureCoordinator(MapEngineChannel channel)
         channel.Queue(
             new SourceAddOp(
                 PolylinesSourceId,
-                new JsonObject { ["type"] = "geojson", ["data"] = JsonNode.Parse(emptyCollection) }
+                new JsonObject { ["type"] = "geojson", ["data"] = JsonNode.Parse(EmptyCollectionJson) }
             )
         );
         channel.Queue(
@@ -256,6 +261,12 @@ internal sealed class MapFeatureCoordinator(MapEngineChannel channel)
             writer.WriteEndObject();
         }
 
+        if (_flushBuffer.WrittenSpan.SequenceEqual(_flushedCirclesPayload))
+        {
+            return;
+        }
+
+        _flushedCirclesPayload = _flushBuffer.WrittenSpan.ToArray();
         channel.PushSourceData(CirclesSourceId, Encoding.UTF8.GetString(_flushBuffer.WrittenSpan), animateMs: null);
     }
 
@@ -303,6 +314,12 @@ internal sealed class MapFeatureCoordinator(MapEngineChannel channel)
             writer.WriteEndObject();
         }
 
+        if (_flushBuffer.WrittenSpan.SequenceEqual(_flushedPolylinesPayload))
+        {
+            return;
+        }
+
+        _flushedPolylinesPayload = _flushBuffer.WrittenSpan.ToArray();
         channel.PushSourceData(PolylinesSourceId, Encoding.UTF8.GetString(_flushBuffer.WrittenSpan), animateMs: null);
     }
 


### PR DESCRIPTION
Closes #150 

Map panning/zooming felt more sluggish than before.

The issue was that we were re-serializing with every detected pan/zoom gesture, even with no changes to the actual underlying data. We now cache the last state and drop the data sync cycle if it is not needed.

Also updated `AGENTS.md` for some added minimal coding style guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "NoChanges" update pattern option to engine shapes stress test UI.

* **Tests**
  * Added comprehensive test coverage for map feature coordinate synchronization and data pushing behavior.

* **Performance**
  * Optimized feature update performance by caching payloads to prevent redundant data synchronization.

* **Chores**
  * Added performance benchmarks for pan operations.
  * Updated code style documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->