### PR TITLE
✨ allow setting control icons

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/src/controls/centerControl.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/controls/centerControl.ts
@@ -1,11 +1,22 @@
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
+import { applyControlIcon } from "./icon";
+
+export const DEFAULT_CENTER_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+      <circle cx="12" cy="12" r="10"/>
+      <line x1="22" y1="12" x2="18" y2="12"/>
+      <line x1="6" y1="12" x2="2" y2="12"/>
+      <line x1="12" y1="6" x2="12" y2="2"/>
+      <line x1="12" y1="22" x2="12" y2="18"/>
+    </svg>`;
 
 export class CenterControl implements IControl {
   private _container: HTMLDivElement | null = null;
   private readonly _onClick: (() => void) | null;
+  private readonly _icon: string;
 
-  constructor(onClick?: () => void) {
+  constructor(onClick?: () => void, icon?: string | null) {
     this._onClick = onClick ?? null;
+    this._icon = icon || DEFAULT_CENTER_ICON;
   }
 
   onAdd(_map: MapLibreMap): HTMLElement {
@@ -18,13 +29,7 @@ export class CenterControl implements IControl {
     button.title = "Re-center map";
     button.setAttribute("aria-label", "Re-center map");
 
-    button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"/>
-      <line x1="22" y1="12" x2="18" y2="12"/>
-      <line x1="6" y1="12" x2="2" y2="12"/>
-      <line x1="12" y1="6" x2="12" y2="2"/>
-      <line x1="12" y1="22" x2="12" y2="18"/>
-    </svg>`;
+    applyControlIcon(button, this._icon);
 
     button.addEventListener("click", () => this._handleClick());
     this._container.appendChild(button);

--- a/src/Spillgebees.Blazor.Map.Assets/src/controls/fullscreenControl.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/controls/fullscreenControl.test.ts
@@ -1,0 +1,118 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+import { describe, expect, it, vi } from "vitest";
+import type { FullscreenController } from "../engine/fullscreen";
+import { FullscreenControl } from "./fullscreenControl";
+
+function createMapStub(): MapLibreMap {
+  return { getContainer: vi.fn() } as unknown as MapLibreMap;
+}
+
+interface ControllerStub extends FullscreenController {
+  fire(isFullscreen: boolean): void;
+}
+
+function createControllerStub(): ControllerStub {
+  let state = false;
+  const subscribers: ((value: boolean) => void)[] = [];
+  return {
+    isFullscreen: () => state,
+    enter: vi.fn(async () => {}),
+    exit: vi.fn(async () => {}),
+    toggle: vi.fn(async () => {}),
+    onChange(cb) {
+      subscribers.push(cb);
+      return () => {
+        const index = subscribers.indexOf(cb);
+        if (index >= 0) {
+          subscribers.splice(index, 1);
+        }
+      };
+    },
+    dispose: vi.fn(),
+    fire(isFullscreen: boolean) {
+      state = isFullscreen;
+      for (const cb of [...subscribers]) {
+        cb(isFullscreen);
+      }
+    },
+  };
+}
+
+describe("FullscreenControl", () => {
+  describe("onAdd", () => {
+    it("renders a button with the default enter glyph and accessible name", () => {
+      const control = new FullscreenControl(createControllerStub());
+      const container = control.onAdd(createMapStub());
+
+      expect(container.className).toContain("sgb-map-fullscreen-control");
+      const button = container.querySelector<HTMLButtonElement>("button");
+      expect(button).not.toBeNull();
+      expect(button?.querySelector("svg")).not.toBeNull();
+      expect(button?.getAttribute("aria-label")).toBe("Enter fullscreen");
+    });
+
+    it("honours custom enter and exit icons", () => {
+      const control = new FullscreenControl(createControllerStub(), {
+        enterIcon: '<svg data-testid="custom-enter"></svg>',
+        exitIcon: '<svg data-testid="custom-exit"></svg>',
+        enterTitle: "Go big",
+        exitTitle: "Go small",
+      });
+      const container = control.onAdd(createMapStub());
+
+      const button = container.querySelector<HTMLButtonElement>("button");
+      expect(button?.querySelector("[data-testid=custom-enter]")).not.toBeNull();
+      expect(button?.getAttribute("aria-label")).toBe("Go big");
+      expect(button?.getAttribute("title")).toBe("Go big");
+    });
+  });
+
+  describe("click", () => {
+    it("toggles fullscreen through the controller", () => {
+      const controller = createControllerStub();
+      const control = new FullscreenControl(controller);
+      const container = control.onAdd(createMapStub());
+
+      container.querySelector("button")?.click();
+      expect(controller.toggle).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("state changes", () => {
+    it("swaps to the exit glyph and label when fullscreen is entered", () => {
+      const controller = createControllerStub();
+      const control = new FullscreenControl(controller, {
+        enterIcon: '<svg data-testid="custom-enter"></svg>',
+        exitIcon: '<svg data-testid="custom-exit"></svg>',
+      });
+      const container = control.onAdd(createMapStub());
+      const button = container.querySelector<HTMLButtonElement>("button");
+
+      controller.fire(true);
+
+      expect(button?.querySelector("[data-testid=custom-exit]")).not.toBeNull();
+      expect(button?.querySelector("[data-testid=custom-enter]")).toBeNull();
+      expect(button?.getAttribute("aria-label")).toBe("Exit fullscreen");
+      expect(button?.getAttribute("title")).toBe("Exit fullscreen");
+    });
+  });
+
+  describe("onRemove", () => {
+    it("unsubscribes from the controller and removes the DOM", () => {
+      const controller = createControllerStub();
+      const control = new FullscreenControl(controller);
+      const container = control.onAdd(createMapStub());
+      document.body.appendChild(container);
+
+      control.onRemove();
+
+      expect(document.body.contains(container)).toBe(false);
+      // a state change after removal must not touch detached DOM
+      expect(() => controller.fire(true)).not.toThrow();
+    });
+
+    it("does not throw when called without prior onAdd", () => {
+      expect(() => new FullscreenControl(createControllerStub()).onRemove()).not.toThrow();
+    });
+  });
+});

--- a/src/Spillgebees.Blazor.Map.Assets/src/controls/fullscreenControl.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/controls/fullscreenControl.ts
@@ -1,0 +1,86 @@
+import type { IControl, Map as MapLibreMap } from "maplibre-gl";
+import type { FullscreenController } from "../engine/fullscreen";
+import { applyControlIcon } from "./icon";
+
+// A first-class fullscreen control we fully own (modelled on CenterControl), so its icons are
+// trivially overridable and it shares the one FullscreenController with the imperative API.
+// The default glyphs match MapLibre's enter/shrink icons so an un-customised control looks
+// unchanged. Icon swaps happen only on the controller's change event — never per frame.
+
+export const DEFAULT_FULLSCREEN_ENTER_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+  <path d="M4 9V4h5" />
+  <path d="M20 9V4h-5" />
+  <path d="M4 15v5h5" />
+  <path d="M20 15v5h-5" />
+</svg>`;
+
+export const DEFAULT_FULLSCREEN_EXIT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+  <path d="M9 4v5H4" />
+  <path d="M15 4v5h5" />
+  <path d="M9 20v-5H4" />
+  <path d="M15 20v-5h5" />
+</svg>`;
+
+export interface FullscreenControlIcons {
+  enterIcon?: string | null;
+  exitIcon?: string | null;
+  enterTitle?: string | null;
+  exitTitle?: string | null;
+}
+
+export class FullscreenControl implements IControl {
+  private readonly _controller: FullscreenController;
+  private readonly _enterIcon: string;
+  private readonly _exitIcon: string;
+  private readonly _enterTitle: string;
+  private readonly _exitTitle: string;
+  private _container: HTMLDivElement | null = null;
+  private _button: HTMLButtonElement | null = null;
+  private _unsubscribe: (() => void) | null = null;
+
+  constructor(controller: FullscreenController, icons?: FullscreenControlIcons) {
+    this._controller = controller;
+    this._enterIcon = icons?.enterIcon || DEFAULT_FULLSCREEN_ENTER_ICON;
+    this._exitIcon = icons?.exitIcon || DEFAULT_FULLSCREEN_EXIT_ICON;
+    this._enterTitle = icons?.enterTitle || "Enter fullscreen";
+    this._exitTitle = icons?.exitTitle || "Exit fullscreen";
+  }
+
+  onAdd(_map: MapLibreMap): HTMLElement {
+    this._container = document.createElement("div");
+    this._container.className = "maplibregl-ctrl sgb-map-ctrl-group sgb-map-fullscreen-control";
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "sgb-map-fullscreen-control-button";
+    button.addEventListener("click", () => void this._controller.toggle());
+    this._button = button;
+    this._container.appendChild(button);
+
+    this._render(this._controller.isFullscreen());
+    this._unsubscribe = this._controller.onChange((isFullscreen) => this._render(isFullscreen));
+
+    return this._container;
+  }
+
+  onRemove(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = null;
+    this._container?.remove();
+    this._container = null;
+    this._button = null;
+  }
+
+  private _render(isFullscreen: boolean): void {
+    if (!this._button) {
+      return;
+    }
+
+    // the accessible name describes the action the button performs next (Enter/Exit), matching
+    // MapLibre's own control; a separate aria-pressed alongside a changing label would be redundant
+    const title = isFullscreen ? this._exitTitle : this._enterTitle;
+    applyControlIcon(this._button, isFullscreen ? this._exitIcon : this._enterIcon);
+    this._button.title = title;
+    this._button.setAttribute("aria-label", title);
+  }
+}

--- a/src/Spillgebees.Blazor.Map.Assets/src/controls/icon.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/controls/icon.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { applyControlIcon } from "./icon";
+
+const ICON_A = '<svg data-testid="icon-a" viewBox="0 0 24 24"><path d="M1 1" /></svg>';
+const ICON_B = '<svg data-testid="icon-b" viewBox="0 0 24 24"><path d="M2 2" /></svg>';
+
+describe("applyControlIcon", () => {
+  it("renders the SVG markup into the button", () => {
+    const button = document.createElement("button");
+
+    applyControlIcon(button, ICON_A);
+
+    expect(button.querySelector("svg")).not.toBeNull();
+    expect(button.querySelector("[data-testid=icon-a]")).not.toBeNull();
+  });
+
+  it("replaces the DOM when the markup changes", () => {
+    const button = document.createElement("button");
+    applyControlIcon(button, ICON_A);
+    applyControlIcon(button, ICON_B);
+
+    expect(button.querySelector("[data-testid=icon-a]")).toBeNull();
+    expect(button.querySelector("[data-testid=icon-b]")).not.toBeNull();
+  });
+});

--- a/src/Spillgebees.Blazor.Map.Assets/src/controls/icon.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/controls/icon.ts
@@ -1,0 +1,15 @@
+// Shared icon slot for the controls we own (center, fullscreen, …). A single chokepoint for
+// rendering SVG markup into a control button, so the two controls stay consistent and there is
+// one place to evolve icon handling. Icons are only (re)applied on control add and on a genuine
+// glyph swap (enter↔exit) — never on a hot path.
+
+/**
+ * Renders SVG markup into a control button.
+ *
+ * SECURITY: `svg` is assigned via `innerHTML`. Pass only trusted, author-controlled markup —
+ * never user-supplied content — or it becomes an XSS sink. Callers surface the same warning on
+ * their public icon parameters.
+ */
+export function applyControlIcon(button: HTMLElement, svg: string): void {
+  button.innerHTML = svg;
+}

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/bootstrap.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/bootstrap.ts
@@ -8,6 +8,7 @@ import type { OverlayStyleRequestOptions } from "../interfaces/spillgebees";
 import { buildStyleFromOptions } from "../styles/base-style";
 import { applyOverlayStyles, validateComposedGlyphs } from "../styles/composition";
 import { type ControlsController, createControlsController } from "./controls";
+import { createFullscreenController, type FullscreenController } from "./fullscreen";
 import { createMarkerController, createMarkerPopup, type MarkerController } from "./markers";
 import type { MapConfigData, Op } from "./ops";
 import { createPopupController, type PopupController } from "./popups";
@@ -44,6 +45,7 @@ interface EngineInstance {
   engine: Engine;
   markers: MarkerController;
   controls: ControlsController;
+  fullscreen: FullscreenController;
   popups: PopupController;
   router: DotNetObjectReference;
   baseStyleKey: string;
@@ -240,10 +242,16 @@ function createMap(container: HTMLElement, optionsJson: string, router: DotNetOb
   // Blazor renders component content (control placeholders, popup content) as a
   // sibling of the map container — resolve DOM conventions from the component root.
   const contentRoot = container.parentElement ?? container;
-  const controls = createControlsController(map, contentRoot, emit);
+  // one fullscreen primitive per map, shared by the built-in control and the imperative API;
+  // state changes (control, API, or the user pressing Esc) surface to .NET as a map event
+  const fullscreen = createFullscreenController(container);
+  fullscreen.onChange(
+    (isFullscreen) => void router.invokeMethodAsync("OnMapEvent", "fullscreenchanged", { isFullscreen }),
+  );
+  const controls = createControlsController(map, contentRoot, emit, fullscreen);
   const popups = createPopupController(map, contentRoot, emit);
   const engine = createEngine(
-    toEngineMap(() => instance, map, markers, controls, popups),
+    toEngineMap(() => instance, map, markers, controls, fullscreen, popups),
     {
       onEvent: emit,
       onError: reportError,
@@ -256,6 +264,7 @@ function createMap(container: HTMLElement, optionsJson: string, router: DotNetOb
     engine,
     markers,
     controls,
+    fullscreen,
     popups,
     router,
     baseStyleKey: styleKey(baseStyle),
@@ -377,6 +386,7 @@ function dispose(container: HTMLElement): void {
   instance.activePopup?.remove();
   instance.popups.dispose();
   instance.controls.dispose();
+  instance.fullscreen.dispose();
   instance.markers.dispose();
   instance.engine.dispose();
   instance.map.remove();
@@ -554,6 +564,7 @@ function toEngineMap(
   map: MapLibreMap,
   markers: MarkerController,
   controls: ControlsController,
+  fullscreen: FullscreenController,
   popups: PopupController,
 ): EngineMap {
   return {
@@ -572,6 +583,15 @@ function toEngineMap(
     },
     configure: (config) => applyConfig(getInstance(), config),
     resize: () => void map.resize(),
+    setFullscreen(state) {
+      if (state == null) {
+        void fullscreen.toggle();
+      } else if (state) {
+        void fullscreen.enter();
+      } else {
+        void fullscreen.exit();
+      }
+    },
     setRequestPolicy(origin, policy) {
       const policies = getInstance().originPolicies;
       if (policy) {

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.test.ts
@@ -20,6 +20,14 @@ function panel(overrides?: Partial<ControlData>): ControlData {
   };
 }
 
+function fullscreen(overrides?: Partial<ControlData>): ControlData {
+  return { kind: "fullscreen", controlId: "fs", visible: true, position: "top-right", order: 200, ...overrides };
+}
+
+function center(overrides?: Partial<ControlData>): ControlData {
+  return { kind: "center", controlId: "center", visible: true, position: "top-left", order: 100, ...overrides };
+}
+
 interface Harness {
   controller: ControlsController;
   map: MockMapInstance;
@@ -128,6 +136,38 @@ describe("engine controls controller", () => {
 
     controller.removeContent("content-1");
     expect(controller.ids()).toEqual([]);
+  });
+
+  it("mounts the fullscreen control as a first-class IControl with a custom icon", () => {
+    const { controller, container } = createHarness();
+
+    controller.set(fullscreen({ enterIcon: '<svg data-testid="fs-enter"></svg>' }));
+
+    expect(controller.ids()).toEqual(["fs"]);
+    expect(container.querySelector(".sgb-map-fullscreen-control")).not.toBeNull();
+    expect(container.querySelector("[data-testid=fs-enter]")).not.toBeNull();
+  });
+
+  it("rebuilds the fullscreen control instance when its icon changes, but reuses it otherwise", () => {
+    const { controller, map } = createHarness();
+    controller.set(fullscreen({ enterIcon: '<svg data-testid="a"></svg>' }));
+    const first = (map.addControl as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+
+    controller.set(fullscreen({ enterIcon: '<svg data-testid="b"></svg>' }));
+    const second = (map.addControl as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(second).not.toBe(first);
+
+    controller.set(fullscreen({ enterIcon: '<svg data-testid="b"></svg>', order: 250 }));
+    const third = (map.addControl as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(third).toBe(second);
+  });
+
+  it("threads a custom icon into the center control", () => {
+    const { controller, container } = createHarness();
+
+    controller.set(center({ icon: '<svg data-testid="center-custom"></svg>' }));
+
+    expect(container.querySelector("[data-testid=center-custom]")).not.toBeNull();
   });
 
   it("routes panel open state through the engine event channel", () => {

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.ts
@@ -6,7 +6,6 @@
 // surfaces through an engine event handler id instead of a DotNet reference.
 
 import {
-  FullscreenControl,
   GeolocateControl,
   type IControl,
   type Map as MapLibreMap,
@@ -16,9 +15,11 @@ import {
 } from "maplibre-gl";
 import { CenterControl } from "../controls/centerControl";
 import { ContentControl } from "../controls/contentControl";
+import { FullscreenControl } from "../controls/fullscreenControl";
 import { LegendControl } from "../controls/legendControl";
 import { PanelControl } from "../controls/panelControl";
 import type { IContentMapControl, ILegendMapControl, IPanelMapControl } from "../interfaces/controls";
+import { createFullscreenController, type FullscreenController } from "./fullscreen";
 import type { ControlContentEvents, ControlData } from "./ops";
 
 export interface ControlsController {
@@ -55,6 +56,8 @@ function findByAttribute(container: HTMLElement, attribute: string, id: string):
 }
 
 function nativeSignature(control: ControlData): string {
+  // computed only on the cold control-set/recompose path, never per frame — a changed icon must
+  // force a rebuild, so the raw markup is part of the key
   return JSON.stringify([
     control.kind,
     control.showCompass,
@@ -62,6 +65,11 @@ function nativeSignature(control: ControlData): string {
     control.unit,
     control.trackUser,
     control.sourceId,
+    control.icon,
+    control.enterIcon,
+    control.exitIcon,
+    control.enterTitle,
+    control.exitTitle,
     control.events?.click,
   ]);
 }
@@ -70,6 +78,7 @@ function createNativeControl(
   map: MapLibreMap,
   control: ControlData,
   emit: (handlerId: number, payload: unknown) => void,
+  getFullscreenController: () => FullscreenController,
 ): IControl | null {
   switch (control.kind) {
     case "navigation":
@@ -80,7 +89,12 @@ function createNativeControl(
     case "scale":
       return new ScaleControl({ unit: control.unit as "metric" | "imperial" | "nautical" | undefined });
     case "fullscreen":
-      return new FullscreenControl();
+      return new FullscreenControl(getFullscreenController(), {
+        enterIcon: control.enterIcon,
+        exitIcon: control.exitIcon,
+        enterTitle: control.enterTitle,
+        exitTitle: control.exitTitle,
+      });
     case "geolocate":
       return new GeolocateControl({ trackUserLocation: control.trackUser ?? undefined });
     case "terrain":
@@ -95,7 +109,7 @@ function createNativeControl(
       return new TerrainControl({ source: control.sourceId });
     case "center": {
       const clickHandlerId = control.events?.click;
-      return new CenterControl(clickHandlerId != null ? () => emit(clickHandlerId, {}) : undefined);
+      return new CenterControl(clickHandlerId != null ? () => emit(clickHandlerId, {}) : undefined, control.icon);
     }
     default:
       return null;
@@ -106,12 +120,19 @@ export function createControlsController(
   map: MapLibreMap,
   container: HTMLElement,
   emit: (handlerId: number, payload: unknown) => void,
+  fullscreenController?: FullscreenController,
 ): ControlsController {
   // definitions in set order — set order doubles as declaration order for sorting
   const definitions = new Map<string, ControlData>();
   const nativeControls = new Map<string, NativeControlEntry>();
   const customControls = new Map<string, CustomControlEntry>();
   const attached: { id: string; control: IControl }[] = [];
+
+  // One fullscreen primitive per map, shared with the imperative API when bootstrap supplies
+  // it. When it doesn't (standalone controller use), create one lazily on first fullscreen use.
+  let fullscreen = fullscreenController ?? null;
+  const getFullscreenController = (): FullscreenController =>
+    (fullscreen ??= createFullscreenController(map.getContainer()));
 
   function resolveContentElements(id: string): { placeholder: HTMLElement; content: HTMLElement } | null {
     const placeholder = findByAttribute(container, "data-sgb-control-placeholder", id);
@@ -208,7 +229,7 @@ export function createControlsController(
       return existing.control;
     }
 
-    const control = createNativeControl(map, definition, emit);
+    const control = createNativeControl(map, definition, emit, getFullscreenController);
     if (!control) {
       nativeControls.delete(definition.controlId);
       return null;

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFullscreenController } from "./fullscreen";
+
+// jsdom ships no Fullscreen API, so we fake the bits the controller depends on and drive
+// the `fullscreenchange` event by hand. Two worlds are exercised: a browser that supports
+// the native API, and one that does not (pseudo-fullscreen fallback).
+
+function setFullscreenElement(element: Element | null): void {
+  Object.defineProperty(document, "fullscreenElement", {
+    configurable: true,
+    get: () => element,
+  });
+}
+
+function fireFullscreenChange(): void {
+  document.dispatchEvent(new Event("fullscreenchange"));
+}
+
+function withNativeApi(target: HTMLElement): {
+  requestFullscreen: ReturnType<typeof vi.fn>;
+  exitFullscreen: ReturnType<typeof vi.fn>;
+} {
+  const requestFullscreen = vi.fn().mockImplementation(() => {
+    setFullscreenElement(target);
+    fireFullscreenChange();
+    return Promise.resolve();
+  });
+  const exitFullscreen = vi.fn().mockImplementation(() => {
+    setFullscreenElement(null);
+    fireFullscreenChange();
+    return Promise.resolve();
+  });
+  target.requestFullscreen = requestFullscreen as unknown as HTMLElement["requestFullscreen"];
+  Object.defineProperty(document, "exitFullscreen", { configurable: true, value: exitFullscreen });
+  Object.defineProperty(document, "fullscreenEnabled", { configurable: true, value: true });
+  setFullscreenElement(null);
+  return { requestFullscreen, exitFullscreen };
+}
+
+function withoutNativeApi(target: HTMLElement): void {
+  // a target with no requestFullscreen forces the pseudo-fullscreen path
+  (target as { requestFullscreen?: unknown }).requestFullscreen = undefined;
+  Object.defineProperty(document, "fullscreenEnabled", { configurable: true, value: false });
+}
+
+afterEach(() => {
+  setFullscreenElement(null);
+});
+
+describe("createFullscreenController", () => {
+  describe("native Fullscreen API", () => {
+    it("enters fullscreen on the target and reflects state", async () => {
+      const target = document.createElement("div");
+      const api = withNativeApi(target);
+      const controller = createFullscreenController(target);
+
+      expect(controller.isFullscreen()).toBe(false);
+      await controller.enter();
+
+      expect(api.requestFullscreen).toHaveBeenCalledTimes(1);
+      expect(controller.isFullscreen()).toBe(true);
+    });
+
+    it("exits fullscreen", async () => {
+      const target = document.createElement("div");
+      const api = withNativeApi(target);
+      const controller = createFullscreenController(target);
+      await controller.enter();
+
+      await controller.exit();
+
+      expect(api.exitFullscreen).toHaveBeenCalledTimes(1);
+      expect(controller.isFullscreen()).toBe(false);
+    });
+
+    it("toggle flips the current state", async () => {
+      const target = document.createElement("div");
+      withNativeApi(target);
+      const controller = createFullscreenController(target);
+
+      await controller.toggle();
+      expect(controller.isFullscreen()).toBe(true);
+      await controller.toggle();
+      expect(controller.isFullscreen()).toBe(false);
+    });
+
+    it("notifies subscribers on state change and stops after unsubscribe", async () => {
+      const target = document.createElement("div");
+      withNativeApi(target);
+      const controller = createFullscreenController(target);
+      const observed: boolean[] = [];
+      const unsubscribe = controller.onChange((value) => observed.push(value));
+
+      await controller.enter();
+      await controller.exit();
+      unsubscribe();
+      await controller.enter();
+
+      expect(observed).toEqual([true, false]);
+    });
+
+    it("dispose detaches listeners", async () => {
+      const target = document.createElement("div");
+      withNativeApi(target);
+      const controller = createFullscreenController(target);
+      const observed: boolean[] = [];
+      controller.onChange((value) => observed.push(value));
+
+      controller.dispose();
+      // a stray native change after dispose must not reach subscribers
+      setFullscreenElement(target);
+      fireFullscreenChange();
+
+      expect(observed).toEqual([]);
+    });
+  });
+
+  describe("pseudo-fullscreen fallback", () => {
+    it("toggles a fallback class and reports state when the API is unavailable", async () => {
+      const target = document.createElement("div");
+      withoutNativeApi(target);
+      const controller = createFullscreenController(target);
+      const observed: boolean[] = [];
+      controller.onChange((value) => observed.push(value));
+
+      await controller.enter();
+      expect(controller.isFullscreen()).toBe(true);
+      expect(target.classList.contains("sgb-map-pseudo-fullscreen")).toBe(true);
+
+      await controller.exit();
+      expect(controller.isFullscreen()).toBe(false);
+      expect(target.classList.contains("sgb-map-pseudo-fullscreen")).toBe(false);
+      expect(observed).toEqual([true, false]);
+    });
+  });
+});

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.test.ts
@@ -132,5 +132,18 @@ describe("createFullscreenController", () => {
       expect(target.classList.contains("sgb-map-pseudo-fullscreen")).toBe(false);
       expect(observed).toEqual([true, false]);
     });
+
+    it("clears the fallback class and state on dispose", async () => {
+      const target = document.createElement("div");
+      withoutNativeApi(target);
+      const controller = createFullscreenController(target);
+      await controller.enter();
+      expect(target.classList.contains("sgb-map-pseudo-fullscreen")).toBe(true);
+
+      controller.dispose();
+
+      expect(target.classList.contains("sgb-map-pseudo-fullscreen")).toBe(false);
+      expect(controller.isFullscreen()).toBe(false);
+    });
   });
 });

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.ts
@@ -1,0 +1,121 @@
+// The single source of truth for fullscreen behaviour, shared by the built-in control
+// (controls/fullscreenControl.ts) and the imperative map API (SgbMap.ToggleFullscreenAsync).
+// Mirrors MapLibre's own FullscreenControl mechanics: the native Fullscreen API when present,
+// a pseudo-fullscreen CSS fallback otherwise. State changes are event-driven only — there is
+// no polling and nothing runs on the render loop.
+
+const PSEUDO_FULLSCREEN_CLASS = "sgb-map-pseudo-fullscreen";
+
+export interface FullscreenController {
+  isFullscreen(): boolean;
+  enter(): Promise<void>;
+  exit(): Promise<void>;
+  toggle(): Promise<void>;
+  /** Subscribe to state changes; returns an unsubscribe function. */
+  onChange(callback: (isFullscreen: boolean) => void): () => void;
+  dispose(): void;
+}
+
+// Older Safari / iPadOS expose the Fullscreen API under webkit prefixes; mirror MapLibre's own
+// control by resolving whichever variant the browser ships. iPhone Safari ships neither, so we
+// fall back to pseudo-fullscreen (a CSS class that fills the viewport).
+interface WebkitFullscreenTarget extends HTMLElement {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+}
+interface WebkitFullscreenDocument extends Document {
+  webkitFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+}
+
+export function createFullscreenController(target: HTMLElement): FullscreenController {
+  const subscribers = new Set<(isFullscreen: boolean) => void>();
+
+  const webkitTarget = target as WebkitFullscreenTarget;
+  const webkitDocument = document as WebkitFullscreenDocument;
+  const useStandard = typeof target.requestFullscreen === "function";
+  const useWebkit = !useStandard && typeof webkitTarget.webkitRequestFullscreen === "function";
+  const apiSupported = useStandard || useWebkit;
+  const changeEvent = useWebkit ? "webkitfullscreenchange" : "fullscreenchange";
+  const fullscreenElement = (): Element | null =>
+    useWebkit ? (webkitDocument.webkitFullscreenElement ?? null) : (document.fullscreenElement ?? null);
+  const requestFullscreen = (): Promise<void> | void =>
+    useWebkit ? webkitTarget.webkitRequestFullscreen?.() : target.requestFullscreen();
+  const exitFullscreen = (): Promise<void> | void =>
+    useWebkit ? webkitDocument.webkitExitFullscreen?.() : document.exitFullscreen();
+
+  let pseudoActive = false;
+  let lastState = false;
+
+  const nativeActive = (): boolean => fullscreenElement() === target;
+  const current = (): boolean => (apiSupported ? nativeActive() : pseudoActive);
+
+  const notify = (): void => {
+    const state = current();
+    if (state === lastState) {
+      return;
+    }
+
+    lastState = state;
+    for (const callback of [...subscribers]) {
+      callback(state);
+    }
+  };
+
+  const onNativeChange = (): void => notify();
+  if (apiSupported) {
+    document.addEventListener(changeEvent, onNativeChange);
+  }
+
+  const enter = async (): Promise<void> => {
+    if (current()) {
+      return;
+    }
+
+    if (apiSupported) {
+      // a denied request (no user gesture, permissions policy) rejects; that is an expected,
+      // benign outcome — state stays false (derived from the change event), so just swallow it
+      try {
+        await requestFullscreen();
+      } catch {}
+    } else {
+      pseudoActive = true;
+      target.classList.add(PSEUDO_FULLSCREEN_CLASS);
+      notify();
+    }
+  };
+
+  const exit = async (): Promise<void> => {
+    if (!current()) {
+      return;
+    }
+
+    if (apiSupported) {
+      try {
+        await exitFullscreen();
+      } catch {}
+    } else {
+      pseudoActive = false;
+      target.classList.remove(PSEUDO_FULLSCREEN_CLASS);
+      notify();
+    }
+  };
+
+  return {
+    isFullscreen: current,
+    enter,
+    exit,
+    toggle: () => (current() ? exit() : enter()),
+    onChange(callback) {
+      subscribers.add(callback);
+      return () => {
+        subscribers.delete(callback);
+      };
+    },
+    dispose() {
+      if (apiSupported) {
+        document.removeEventListener(changeEvent, onNativeChange);
+      }
+      subscribers.clear();
+    },
+  };
+}

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/fullscreen.ts
@@ -115,6 +115,9 @@ export function createFullscreenController(target: HTMLElement): FullscreenContr
       if (apiSupported) {
         document.removeEventListener(changeEvent, onNativeChange);
       }
+      // a pseudo-fullscreen fallback would otherwise strand the container fixed/full-viewport
+      pseudoActive = false;
+      target.classList.remove(PSEUDO_FULLSCREEN_CLASS);
       subscribers.clear();
     },
   };

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/ops.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/ops.ts
@@ -169,6 +169,13 @@ export interface ControlData {
   label?: string | null;
   isOpen?: boolean | null;
   maxWidth?: string | null;
+  /** Custom SVG icon for single-glyph controls we own (e.g. center). */
+  icon?: string | null;
+  /** Custom SVG icons + titles for the two-state fullscreen control. */
+  enterIcon?: string | null;
+  exitIcon?: string | null;
+  enterTitle?: string | null;
+  exitTitle?: string | null;
   /** Engine event handler ids (e.g. center-control click). */
   events?: { click?: number | null } | null;
 }
@@ -241,6 +248,7 @@ export type Op =
   | { op: "popup.close" }
   | { op: "map.configure"; config: MapConfigData }
   | { op: "map.resize" }
+  | { op: "fullscreen.set"; fullscreen?: boolean | null }
   | { op: "map.requestPolicy"; origin: string; policy?: string | null }
   | { op: "camera.flyTo"; center?: LatLng | null; zoom?: number | null; bearing?: number | null; pitch?: number | null }
   | {

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.test.ts
@@ -130,6 +130,9 @@ function createHarness(options: { sourcesSupportUpdateData?: boolean } = {}): Ha
     setControl(control) {
       log.push(`setControl:${control.controlId}`);
     },
+    setFullscreen(state) {
+      log.push(`setFullscreen:${state}`);
+    },
     removeControl(id) {
       log.push(`removeControl:${id}`);
     },

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.ts
@@ -83,6 +83,8 @@ export interface EngineMap {
   /** Map-level configuration (camera limits, projection, pixel ratio). */
   configure(config: MapConfigData): void;
   resize(): void;
+  /** Drives the shared fullscreen primitive; null toggles, a bool forces the state. */
+  setFullscreen(fullscreen: boolean | null): void;
   /** Per-origin referrer policy for tile requests (transformRequest). */
   setRequestPolicy(origin: string, policy: string | null): void;
   flyTo(options: Record<string, unknown>): void;
@@ -776,6 +778,9 @@ export function createEngine(map: EngineMap, options: EngineOptions = {}): Engin
         break;
       case "map.resize":
         map.resize();
+        break;
+      case "fullscreen.set":
+        map.setFullscreen(op.fullscreen ?? null);
         break;
       case "map.requestPolicy":
         map.setRequestPolicy(op.origin, op.policy ?? null);

--- a/src/Spillgebees.Blazor.Map.Assets/src/styles.scss
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles.scss
@@ -241,6 +241,26 @@
   }
 }
 
+.sgb-map-fullscreen-control {
+  .sgb-map-fullscreen-control-button {
+    // button styling inherited from .sgb-map-ctrl-group button; size a custom icon to match
+    svg {
+      width: var(--sgb-map-ctrl-icon-size);
+      height: var(--sgb-map-ctrl-icon-size);
+    }
+  }
+}
+
+// pseudo-fullscreen fallback for browsers without the Fullscreen API (e.g. iPhone Safari);
+// maplibre resizes the canvas via its container ResizeObserver once the element fills the viewport
+.sgb-map-pseudo-fullscreen {
+  position: fixed !important;
+  inset: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  z-index: 99999;
+}
+
 // generic Blazor-rendered custom control
 .sgb-map-custom-control {
   color: var(--sgb-map-ctrl-text);

--- a/src/Spillgebees.Blazor.Map.Assets/tests/browser/integration/engine-fullscreen.spec.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/tests/browser/integration/engine-fullscreen.spec.ts
@@ -1,0 +1,43 @@
+import { expect, type Page, test } from "@playwright/test";
+
+// Fullscreen control coverage: a custom UX SVG renders inside our first-class control, the
+// stock control still renders by default, and a host-owned button drives the imperative API.
+// True OS fullscreen transitions are unreliable under headless Chromium, so the deterministic
+// enter/exit/toggle behaviour is covered by the engine/fullscreen.test.ts unit suite; here we
+// assert the wiring is live and side-effect-free.
+
+const PAGE_ROUTE = "/engine-fullscreen-functional-test";
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto(PAGE_ROUTE, { waitUntil: "domcontentloaded" });
+  await expect(page.locator(".sgb-map-container canvas")).toBeVisible({ timeout: 60000 });
+}
+
+test.describe("engine fullscreen control", () => {
+  test("renders the custom UX SVG inside the fullscreen control button", async ({ page }) => {
+    await openFixture(page);
+
+    const customControl = page.locator(".sgb-map-fullscreen-control");
+    await expect(customControl.first()).toBeVisible({ timeout: 20000 });
+    await expect(page.locator("[data-testid=fs-custom-enter]")).toBeVisible();
+  });
+
+  test("the default fullscreen control still renders a glyph button", async ({ page }) => {
+    await openFixture(page);
+
+    // two controls on the page; the un-customised one must still render an svg button
+    const buttons = page.locator(".sgb-map-fullscreen-control button:has(svg)");
+    await expect(buttons).toHaveCount(2, { timeout: 20000 });
+  });
+
+  test("the host toggle button drives the imperative API without erroring", async ({ page }) => {
+    await openFixture(page);
+
+    await expect(page.getByTestId("fullscreen-state")).toHaveText("fullscreen: false");
+    await page.getByTestId("custom-toggle").click();
+
+    // the call path must not surface a map error regardless of headless fullscreen support
+    await expect(page.getByTestId("map-error")).toHaveCount(0);
+    await expect(page.getByTestId("fullscreen-state")).toBeVisible();
+  });
+});

--- a/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineFullscreenFunctionalTest.razor
+++ b/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineFullscreenFunctionalTest.razor
@@ -1,0 +1,66 @@
+@page "/engine-fullscreen-functional-test"
+
+<main class="e2e-shell">
+    <h1>Engine fullscreen functional test</h1>
+    <p>Fullscreen control with a custom UX-supplied SVG, plus a custom toggle button driving the imperative API.</p>
+
+    @if (_lastError is not null)
+    {
+        <p style="color: #b91c1c;" data-testid="map-error">@_lastError</p>
+    }
+
+    <button type="button" data-testid="custom-toggle" @onclick="ToggleAsync">Toggle fullscreen</button>
+    <p data-testid="fullscreen-state">fullscreen: @_isFullscreen.ToString().ToLowerInvariant()</p>
+
+    <div id="engine-fullscreen-frame" class="stress-map-frame">
+        <SgbMap @ref="_map"
+                Style="@BaseStyle"
+                Center="@(new Coordinate(49.61, 6.14))"
+                Zoom="12"
+                Height="480px"
+                Width="100%"
+                OnFullscreenChanged="HandleFullscreenChanged"
+                OnMapError="@HandleMapError">
+            <MapControls>
+                <FullscreenMapControl Id="fs-custom"
+                                      Position="ControlPosition.TopRight"
+                                      EnterIcon="@CustomEnterIcon"
+                                      ExitIcon="@CustomExitIcon" />
+                <FullscreenMapControl Id="fs-default" Position="ControlPosition.TopLeft" />
+            </MapControls>
+        </SgbMap>
+    </div>
+</main>
+
+@code {
+    private const string CustomEnterIcon =
+        """<svg data-testid="fs-custom-enter" viewBox="0 0 24 24" width="20" height="20"><path d="M3 3h6M3 3v6" /></svg>""";
+
+    private const string CustomExitIcon =
+        """<svg data-testid="fs-custom-exit" viewBox="0 0 24 24" width="20" height="20"><path d="M9 9H3M9 9V3" /></svg>""";
+
+    private static readonly MapStyle BaseStyle = MapStyle
+        .FromRasterUrl(
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4YWMDAAMQAUEiFmcFAAAAAElFTkSuQmCC",
+            "base"
+        )
+        .WithId("base");
+
+    private SgbMap? _map;
+    private bool _isFullscreen;
+    private string? _lastError;
+
+    private Task ToggleAsync() => _map?.ToggleFullscreenAsync() ?? Task.CompletedTask;
+
+    private void HandleFullscreenChanged(bool isFullscreen)
+    {
+        _isFullscreen = isFullscreen;
+        StateHasChanged();
+    }
+
+    private void HandleMapError(Exception exception)
+    {
+        _lastError = exception.Message;
+        StateHasChanged();
+    }
+}

--- a/src/Spillgebees.Blazor.Map.Tests/Engine/EngineOpsSerializationTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Engine/EngineOpsSerializationTests.cs
@@ -109,6 +109,79 @@ public class EngineOpsSerializationTests
     }
 
     [Test]
+    public void Should_serialize_fullscreen_control_with_custom_icons()
+    {
+        // arrange
+        var setOp = new ControlSetOp(
+            EngineControl.From(
+                new FullscreenControlDefinition(
+                    EnterIcon: "\u003Csvg data-enter\u003E\u003C/svg\u003E",
+                    ExitIcon: "\u003Csvg data-exit\u003E\u003C/svg\u003E",
+                    EnterTitle: "Go big",
+                    ExitTitle: "Go small"
+                )
+            )
+        );
+
+        // act
+        var json = Serialize(setOp);
+
+        // assert — System.Text.Json HTML-escapes the SVG angle brackets on the wire (JSON.parse
+        // decodes them back JS-side); this is the safe default and is intentional
+        json.Should()
+            .Be(
+                """[{"op":"control.set","control":{"kind":"fullscreen","controlId":"fullscreen","visible":true,"position":"top-right","order":200,"enterIcon":"\u003Csvg data-enter\u003E\u003C/svg\u003E","exitIcon":"\u003Csvg data-exit\u003E\u003C/svg\u003E","enterTitle":"Go big","exitTitle":"Go small"}}]"""
+            );
+    }
+
+    [Test]
+    public void Should_keep_the_default_fullscreen_wire_shape_when_no_icons_are_set()
+    {
+        // arrange — the icon fields are purely additive; an un-customised control is byte-for-byte
+        // identical to the pre-feature wire shape
+        var setOp = new ControlSetOp(EngineControl.From(new FullscreenControlDefinition()));
+
+        // act
+        var json = Serialize(setOp);
+
+        // assert
+        json.Should()
+            .Be(
+                """[{"op":"control.set","control":{"kind":"fullscreen","controlId":"fullscreen","visible":true,"position":"top-right","order":200}}]"""
+            );
+    }
+
+    [Test]
+    public void Should_serialize_center_control_with_a_custom_icon()
+    {
+        // arrange
+        var setOp = new ControlSetOp(EngineControl.From(new CenterControlDefinition(Icon: "\u003Csvg data-center\u003E\u003C/svg\u003E")));
+
+        // act
+        var json = Serialize(setOp);
+
+        // assert
+        json.Should()
+            .Be(
+                """[{"op":"control.set","control":{"kind":"center","controlId":"center","visible":true,"position":"top-left","order":100,"icon":"\u003Csvg data-center\u003E\u003C/svg\u003E"}}]"""
+            );
+    }
+
+    [Test]
+    public void Should_serialize_fullscreen_set_ops_with_toggle_when_state_is_null()
+    {
+        // arrange — null means "toggle", a concrete bool means "force into that state"
+        // act
+        var json = Serialize(new FullscreenSetOp(true), new FullscreenSetOp(false), new FullscreenSetOp(null));
+
+        // assert
+        json.Should()
+            .Be(
+                """[{"op":"fullscreen.set","fullscreen":true},{"op":"fullscreen.set","fullscreen":false},{"op":"fullscreen.set"}]"""
+            );
+    }
+
+    [Test]
     public void Should_serialize_map_config_and_camera_ops()
     {
         // arrange

--- a/src/Spillgebees.Blazor.Map.Tests/Models/Controls/ControlIconTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Models/Controls/ControlIconTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+
+namespace Spillgebees.Blazor.Map.Tests.Models.Controls;
+
+public class ControlIconTests
+{
+    [Test]
+    public void Fullscreen_definition_should_default_its_icons_to_null()
+    {
+        // arrange / act
+        var control = new FullscreenControlDefinition();
+
+        // assert — un-customised controls opt out of icon overrides entirely
+        control.EnterIcon.Should().BeNull();
+        control.ExitIcon.Should().BeNull();
+        control.EnterTitle.Should().BeNull();
+        control.ExitTitle.Should().BeNull();
+    }
+
+    [Test]
+    public void Fullscreen_definition_should_carry_custom_icons()
+    {
+        // arrange / act
+        var control = new FullscreenControlDefinition(
+            EnterIcon: "<svg data-enter></svg>",
+            ExitIcon: "<svg data-exit></svg>",
+            EnterTitle: "Go big",
+            ExitTitle: "Go small"
+        );
+
+        // assert
+        control.EnterIcon.Should().Be("<svg data-enter></svg>");
+        control.ExitIcon.Should().Be("<svg data-exit></svg>");
+        control.EnterTitle.Should().Be("Go big");
+        control.ExitTitle.Should().Be("Go small");
+    }
+
+    [Test]
+    public void Center_definition_should_carry_a_custom_icon()
+    {
+        // arrange / act
+        var control = new CenterControlDefinition(Icon: "<svg data-center></svg>");
+
+        // assert
+        control.Icon.Should().Be("<svg data-center></svg>");
+    }
+}

--- a/src/Spillgebees.Blazor.Map/Components/CenterMapControl.cs
+++ b/src/Spillgebees.Blazor.Map/Components/CenterMapControl.cs
@@ -25,6 +25,13 @@ public sealed class CenterMapControl : ComponentBase, IAsyncDisposable
     [Parameter]
     public bool Visible { get; set; } = true;
 
+    /// <summary>
+    /// Optional custom SVG markup for the control glyph. Trusted markup; do not pass user-supplied
+    /// content. Defaults to the built-in glyph when null.
+    /// </summary>
+    [Parameter]
+    public string? Icon { get; set; }
+
     [CascadingParameter]
     private MapControlRegistryContext? _registry { get; set; }
 
@@ -41,5 +48,5 @@ public sealed class CenterMapControl : ComponentBase, IAsyncDisposable
     /// <inheritdoc />
     public ValueTask DisposeAsync() => _registration.DisposeAsync(_registry);
 
-    private CenterControlDefinition BuildControl() => new(Id, Visible, Position, Order);
+    private CenterControlDefinition BuildControl() => new(Id, Visible, Position, Order, Icon);
 }

--- a/src/Spillgebees.Blazor.Map/Components/FullscreenMapControl.cs
+++ b/src/Spillgebees.Blazor.Map/Components/FullscreenMapControl.cs
@@ -25,6 +25,28 @@ public sealed class FullscreenMapControl : ComponentBase, IAsyncDisposable
     [Parameter]
     public bool Visible { get; set; } = true;
 
+    /// <summary>
+    /// Optional custom SVG markup for the "enter fullscreen" glyph. Trusted markup; do not pass
+    /// user-supplied content. Defaults to the built-in glyph when null.
+    /// </summary>
+    [Parameter]
+    public string? EnterIcon { get; set; }
+
+    /// <summary>
+    /// Optional custom SVG markup for the "exit fullscreen" glyph. Trusted markup; do not pass
+    /// user-supplied content. Defaults to the built-in glyph when null.
+    /// </summary>
+    [Parameter]
+    public string? ExitIcon { get; set; }
+
+    /// <summary>Optional accessible label/tooltip shown while collapsed. Defaults to "Enter fullscreen".</summary>
+    [Parameter]
+    public string? EnterTitle { get; set; }
+
+    /// <summary>Optional accessible label/tooltip shown while expanded. Defaults to "Exit fullscreen".</summary>
+    [Parameter]
+    public string? ExitTitle { get; set; }
+
     [CascadingParameter]
     private MapControlRegistryContext? _registry { get; set; }
 
@@ -41,5 +63,6 @@ public sealed class FullscreenMapControl : ComponentBase, IAsyncDisposable
     /// <inheritdoc />
     public ValueTask DisposeAsync() => _registration.DisposeAsync(_registry);
 
-    private FullscreenControlDefinition BuildControl() => new(Id, Visible, Position, Order);
+    private FullscreenControlDefinition BuildControl() =>
+        new(Id, Visible, Position, Order, EnterIcon, ExitIcon, EnterTitle, ExitTitle);
 }

--- a/src/Spillgebees.Blazor.Map/Components/SgbMap.Fullscreen.cs
+++ b/src/Spillgebees.Blazor.Map/Components/SgbMap.Fullscreen.cs
@@ -14,14 +14,6 @@ namespace Spillgebees.Blazor.Map;
 public partial class SgbMap
 {
     /// <summary>
-    /// Whether the map is currently presented fullscreen. Updated from every source — the built-in
-    /// control, the imperative API, and the browser (e.g. the user pressing Esc). Observe-only: the
-    /// browser owns fullscreen state, so this is not a two-way-bindable parameter (there is no
-    /// <c>@bind-IsFullscreen</c>); use <see cref="OnFullscreenChanged"/> to react to changes.
-    /// </summary>
-    public bool IsFullscreen { get; private set; }
-
-    /// <summary>
     /// Raised whenever the fullscreen state changes, regardless of what triggered it. This is the
     /// observe-only counterpart to <c>@bind</c> — fullscreen state cannot be pushed via a bound
     /// parameter because the browser grants and revokes it; drive changes with
@@ -29,6 +21,14 @@ public partial class SgbMap
     /// </summary>
     [Parameter]
     public EventCallback<bool> OnFullscreenChanged { get; set; }
+
+    /// <summary>
+    /// Whether the map is currently presented fullscreen. Updated from every source — the built-in
+    /// control, the imperative API, and the browser (e.g. the user pressing Esc). Observe-only: the
+    /// browser owns fullscreen state, so this is not a two-way-bindable parameter (there is no
+    /// <c>@bind-IsFullscreen</c>); use <see cref="OnFullscreenChanged"/> to react to changes.
+    /// </summary>
+    public bool IsFullscreen { get; private set; }
 
     /// <summary>
     /// Presents the map fullscreen. Browsers only grant fullscreen in response to a user gesture,

--- a/src/Spillgebees.Blazor.Map/Components/SgbMap.Fullscreen.cs
+++ b/src/Spillgebees.Blazor.Map/Components/SgbMap.Fullscreen.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Components;
+using Spillgebees.Blazor.Map.Engine;
+
+namespace Spillgebees.Blazor.Map;
+
+/// <summary>
+/// The fullscreen surface of <see cref="SgbMap" />: an imperative API for toggling fullscreen
+/// without placing a control, and the change notification that keeps host UI in sync. Both the
+/// built-in <see cref="FullscreenMapControl" /> and these methods drive the one shared fullscreen
+/// primitive in the engine, so state stays consistent across the control, this API, and the user
+/// pressing Esc.
+/// </summary>
+public partial class SgbMap
+{
+    /// <summary>
+    /// Whether the map is currently presented fullscreen. Updated from every source — the built-in
+    /// control, the imperative API, and the browser (e.g. the user pressing Esc). Observe-only: the
+    /// browser owns fullscreen state, so this is not a two-way-bindable parameter (there is no
+    /// <c>@bind-IsFullscreen</c>); use <see cref="OnFullscreenChanged"/> to react to changes.
+    /// </summary>
+    public bool IsFullscreen { get; private set; }
+
+    /// <summary>
+    /// Raised whenever the fullscreen state changes, regardless of what triggered it. This is the
+    /// observe-only counterpart to <c>@bind</c> — fullscreen state cannot be pushed via a bound
+    /// parameter because the browser grants and revokes it; drive changes with
+    /// <see cref="ToggleFullscreenAsync"/> / <see cref="EnterFullscreenAsync"/> instead.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> OnFullscreenChanged { get; set; }
+
+    /// <summary>
+    /// Presents the map fullscreen. Browsers only grant fullscreen in response to a user gesture,
+    /// so call this from a user-initiated event (e.g. a button click); otherwise the request may be
+    /// denied and the call becomes a no-op. Observe the result via <see cref="OnFullscreenChanged" />.
+    /// </summary>
+    public Task EnterFullscreenAsync() => Channel.QueueAndFlushAsync(new FullscreenSetOp(true));
+
+    /// <summary>Exits fullscreen.</summary>
+    public Task ExitFullscreenAsync() => Channel.QueueAndFlushAsync(new FullscreenSetOp(false));
+
+    /// <summary>
+    /// Toggles the fullscreen state. Entering fullscreen requires a user gesture (see
+    /// <see cref="EnterFullscreenAsync" />); observe the result via <see cref="OnFullscreenChanged" />.
+    /// </summary>
+    public Task ToggleFullscreenAsync() => Channel.QueueAndFlushAsync(new FullscreenSetOp());
+
+    // Routed from the map-event channel ("fullscreenchanged"): the state changed from any source —
+    // the control, the imperative API, or the browser (e.g. the user pressing Esc).
+    private Task HandleFullscreenChangedAsync(JsonElement payload) =>
+        SetFullscreenStateAsync(payload.GetProperty("isFullscreen").GetBoolean());
+
+    private async Task SetFullscreenStateAsync(bool isFullscreen)
+    {
+        if (IsFullscreen == isFullscreen)
+        {
+            return;
+        }
+
+        IsFullscreen = isFullscreen;
+        if (OnFullscreenChanged.HasDelegate)
+        {
+            await OnFullscreenChanged.InvokeAsync(isFullscreen);
+        }
+    }
+}

--- a/src/Spillgebees.Blazor.Map/Components/SgbMap.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/SgbMap.razor.cs
@@ -472,6 +472,9 @@ public partial class SgbMap
                     )
                 );
                 break;
+            case "fullscreenchanged":
+                await HandleFullscreenChangedAsync(payload);
+                break;
             case "error":
                 var message = payload.TryGetProperty("message", out var messageProperty)
                     ? messageProperty.GetString()

--- a/src/Spillgebees.Blazor.Map/Engine/EngineOps.cs
+++ b/src/Spillgebees.Blazor.Map/Engine/EngineOps.cs
@@ -44,6 +44,7 @@ namespace Spillgebees.Blazor.Map.Engine;
 [JsonDerivedType(typeof(PopupCloseOp), "popup.close")]
 [JsonDerivedType(typeof(MapConfigureOp), "map.configure")]
 [JsonDerivedType(typeof(MapResizeOp), "map.resize")]
+[JsonDerivedType(typeof(FullscreenSetOp), "fullscreen.set")]
 [JsonDerivedType(typeof(MapRequestPolicyOp), "map.requestPolicy")]
 [JsonDerivedType(typeof(CameraFlyToOp), "camera.flyTo")]
 [JsonDerivedType(typeof(CameraFitFeaturesOp), "camera.fitFeatures")]
@@ -158,6 +159,11 @@ internal sealed record EngineControl(
     string? Label = null,
     bool? IsOpen = null,
     string? MaxWidth = null,
+    string? Icon = null,
+    string? EnterIcon = null,
+    string? ExitIcon = null,
+    string? EnterTitle = null,
+    string? ExitTitle = null,
     EngineControlEvents? Events = null
 )
 {
@@ -190,7 +196,11 @@ internal sealed record EngineControl(
                 fullscreen.ControlId,
                 fullscreen.Visible,
                 fullscreen.Position,
-                fullscreen.Order
+                fullscreen.Order,
+                EnterIcon: fullscreen.EnterIcon,
+                ExitIcon: fullscreen.ExitIcon,
+                EnterTitle: fullscreen.EnterTitle,
+                ExitTitle: fullscreen.ExitTitle
             ),
             GeolocateControlDefinition geolocate => new(
                 "geolocate",
@@ -214,6 +224,7 @@ internal sealed record EngineControl(
                 center.Visible,
                 center.Position,
                 center.Order,
+                Icon: center.Icon,
                 Events: centerClickHandlerId is null ? null : new EngineControlEvents(Click: centerClickHandlerId)
             ),
             LegendControlDefinition legend => new(
@@ -265,6 +276,12 @@ internal sealed record PopupCloseOp : EngineOp;
 internal sealed record MapConfigureOp(EngineMapConfig Config) : EngineOp;
 
 internal sealed record MapResizeOp : EngineOp;
+
+/// <summary>
+/// Drives the shared fullscreen primitive. <see cref="Fullscreen"/> null toggles; a concrete
+/// value forces the map into that state.
+/// </summary>
+internal sealed record FullscreenSetOp(bool? Fullscreen = null) : EngineOp;
 
 /// <summary>Per-origin referrer policy for tile requests (tile overlays).</summary>
 internal sealed record MapRequestPolicyOp(string Origin, string? Policy = null) : EngineOp;

--- a/src/Spillgebees.Blazor.Map/Models/Controls/MapControlOptions.cs
+++ b/src/Spillgebees.Blazor.Map/Models/Controls/MapControlOptions.cs
@@ -62,13 +62,19 @@ public sealed record ScaleControlDefinition(
 ) : MapControlDefinition(ControlId, Position, Order, Visible);
 
 /// <summary>
-/// A fullscreen control entry.
+/// A fullscreen control entry. <c>EnterIcon</c>/<c>ExitIcon</c> accept custom SVG markup for the
+/// two glyphs (trusted markup; do not pass user-supplied content), and <c>EnterTitle</c>/<c>ExitTitle</c>
+/// override the accessible labels. All default to the built-in values when null.
 /// </summary>
 public sealed record FullscreenControlDefinition(
     string ControlId = "fullscreen",
     bool Visible = true,
     ControlPosition Position = ControlPosition.TopRight,
-    int Order = 200
+    int Order = 200,
+    string? EnterIcon = null,
+    string? ExitIcon = null,
+    string? EnterTitle = null,
+    string? ExitTitle = null
 ) : MapControlDefinition(ControlId, Position, Order, Visible);
 
 /// <summary>
@@ -94,13 +100,16 @@ public sealed record TerrainControlDefinition(
 ) : MapControlDefinition(ControlId, Position, Order, Visible);
 
 /// <summary>
-/// A center control entry that re-centers to current the map options.
+/// A center control entry that re-centers to the current map options. <c>Icon</c> accepts custom
+/// SVG markup for the glyph (trusted markup; do not pass user-supplied content), defaulting to the
+/// built-in glyph when null.
 /// </summary>
 public sealed record CenterControlDefinition(
     string ControlId = "center",
     bool Visible = true,
     ControlPosition Position = ControlPosition.TopLeft,
-    int Order = 100
+    int Order = 100,
+    string? Icon = null
 ) : MapControlDefinition(ControlId, Position, Order, Visible);
 
 /// <summary>

--- a/src/Spillgebees.Blazor.Map/PublicAPI.Shipped.txt
+++ b/src/Spillgebees.Blazor.Map/PublicAPI.Shipped.txt
@@ -55,10 +55,14 @@ Spillgebees.Blazor.Map.ButtonMapControl.Variant.set -> void
 Spillgebees.Blazor.Map.ButtonMapControl.Visible.get -> bool
 Spillgebees.Blazor.Map.ButtonMapControl.Visible.set -> void
 Spillgebees.Blazor.Map.CenterControlDefinition
-Spillgebees.Blazor.Map.CenterControlDefinition.CenterControlDefinition(string! ControlId = "center", bool Visible = true, Spillgebees.Blazor.Map.ControlPosition Position = Spillgebees.Blazor.Map.ControlPosition.TopLeft, int Order = 100) -> void
+Spillgebees.Blazor.Map.CenterControlDefinition.CenterControlDefinition(string! ControlId = "center", bool Visible = true, Spillgebees.Blazor.Map.ControlPosition Position = Spillgebees.Blazor.Map.ControlPosition.TopLeft, int Order = 100, string? Icon = null) -> void
+Spillgebees.Blazor.Map.CenterControlDefinition.Icon.get -> string?
+Spillgebees.Blazor.Map.CenterControlDefinition.Icon.init -> void
 Spillgebees.Blazor.Map.CenterMapControl
 Spillgebees.Blazor.Map.CenterMapControl.CenterMapControl() -> void
 Spillgebees.Blazor.Map.CenterMapControl.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Spillgebees.Blazor.Map.CenterMapControl.Icon.get -> string?
+Spillgebees.Blazor.Map.CenterMapControl.Icon.set -> void
 Spillgebees.Blazor.Map.CenterMapControl.Id.get -> string!
 Spillgebees.Blazor.Map.CenterMapControl.Id.set -> void
 Spillgebees.Blazor.Map.CenterMapControl.Order.get -> int
@@ -284,9 +288,25 @@ Spillgebees.Blazor.Map.FitBoundsOptions.Padding.init -> void
 Spillgebees.Blazor.Map.FitBoundsOptions.TopLeftPadding.get -> Spillgebees.Blazor.Map.PixelPoint?
 Spillgebees.Blazor.Map.FitBoundsOptions.TopLeftPadding.init -> void
 Spillgebees.Blazor.Map.FullscreenControlDefinition
-Spillgebees.Blazor.Map.FullscreenControlDefinition.FullscreenControlDefinition(string! ControlId = "fullscreen", bool Visible = true, Spillgebees.Blazor.Map.ControlPosition Position = Spillgebees.Blazor.Map.ControlPosition.TopRight, int Order = 200) -> void
+Spillgebees.Blazor.Map.FullscreenControlDefinition.EnterIcon.get -> string?
+Spillgebees.Blazor.Map.FullscreenControlDefinition.EnterIcon.init -> void
+Spillgebees.Blazor.Map.FullscreenControlDefinition.EnterTitle.get -> string?
+Spillgebees.Blazor.Map.FullscreenControlDefinition.EnterTitle.init -> void
+Spillgebees.Blazor.Map.FullscreenControlDefinition.ExitIcon.get -> string?
+Spillgebees.Blazor.Map.FullscreenControlDefinition.ExitIcon.init -> void
+Spillgebees.Blazor.Map.FullscreenControlDefinition.ExitTitle.get -> string?
+Spillgebees.Blazor.Map.FullscreenControlDefinition.ExitTitle.init -> void
+Spillgebees.Blazor.Map.FullscreenControlDefinition.FullscreenControlDefinition(string! ControlId = "fullscreen", bool Visible = true, Spillgebees.Blazor.Map.ControlPosition Position = Spillgebees.Blazor.Map.ControlPosition.TopRight, int Order = 200, string? EnterIcon = null, string? ExitIcon = null, string? EnterTitle = null, string? ExitTitle = null) -> void
 Spillgebees.Blazor.Map.FullscreenMapControl
 Spillgebees.Blazor.Map.FullscreenMapControl.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Spillgebees.Blazor.Map.FullscreenMapControl.EnterIcon.get -> string?
+Spillgebees.Blazor.Map.FullscreenMapControl.EnterIcon.set -> void
+Spillgebees.Blazor.Map.FullscreenMapControl.EnterTitle.get -> string?
+Spillgebees.Blazor.Map.FullscreenMapControl.EnterTitle.set -> void
+Spillgebees.Blazor.Map.FullscreenMapControl.ExitIcon.get -> string?
+Spillgebees.Blazor.Map.FullscreenMapControl.ExitIcon.set -> void
+Spillgebees.Blazor.Map.FullscreenMapControl.ExitTitle.get -> string?
+Spillgebees.Blazor.Map.FullscreenMapControl.ExitTitle.set -> void
 Spillgebees.Blazor.Map.FullscreenMapControl.FullscreenMapControl() -> void
 Spillgebees.Blazor.Map.FullscreenMapControl.Id.get -> string!
 Spillgebees.Blazor.Map.FullscreenMapControl.Id.set -> void
@@ -1214,6 +1234,8 @@ Spillgebees.Blazor.Map.SgbMap.CooperativeGestures.set -> void
 Spillgebees.Blazor.Map.SgbMap.Display.get -> Spillgebees.Blazor.Map.MapDisplayState?
 Spillgebees.Blazor.Map.SgbMap.Display.set -> void
 Spillgebees.Blazor.Map.SgbMap.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Spillgebees.Blazor.Map.SgbMap.EnterFullscreenAsync() -> System.Threading.Tasks.Task!
+Spillgebees.Blazor.Map.SgbMap.ExitFullscreenAsync() -> System.Threading.Tasks.Task!
 Spillgebees.Blazor.Map.SgbMap.FitBounds.get -> Spillgebees.Blazor.Map.FitBoundsOptions?
 Spillgebees.Blazor.Map.SgbMap.FitBounds.set -> void
 Spillgebees.Blazor.Map.SgbMap.FitBoundsAsync(Spillgebees.Blazor.Map.FitBoundsOptions! options) -> System.Threading.Tasks.Task!
@@ -1233,6 +1255,7 @@ Spillgebees.Blazor.Map.SgbMap.Images.get -> System.Collections.Generic.IReadOnly
 Spillgebees.Blazor.Map.SgbMap.Images.set -> void
 Spillgebees.Blazor.Map.SgbMap.Interactive.get -> bool
 Spillgebees.Blazor.Map.SgbMap.Interactive.set -> void
+Spillgebees.Blazor.Map.SgbMap.IsFullscreen.get -> bool
 Spillgebees.Blazor.Map.SgbMap.Markers.get -> System.Collections.Generic.IReadOnlyList<Spillgebees.Blazor.Map.Marker!>?
 Spillgebees.Blazor.Map.SgbMap.Markers.set -> void
 Spillgebees.Blazor.Map.SgbMap.MaxBounds.get -> Spillgebees.Blazor.Map.MapBounds?
@@ -1244,6 +1267,8 @@ Spillgebees.Blazor.Map.SgbMap.MinZoom.set -> void
 Spillgebees.Blazor.Map.SgbMap.MoveLayerAsync(string! layerId, string? beforeLayerId = null) -> System.Threading.Tasks.Task!
 Spillgebees.Blazor.Map.SgbMap.OnFollowChanged.get -> Microsoft.AspNetCore.Components.EventCallback<Spillgebees.Blazor.Map.MapFollowChangedEventArgs!>
 Spillgebees.Blazor.Map.SgbMap.OnFollowChanged.set -> void
+Spillgebees.Blazor.Map.SgbMap.OnFullscreenChanged.get -> Microsoft.AspNetCore.Components.EventCallback<bool>
+Spillgebees.Blazor.Map.SgbMap.OnFullscreenChanged.set -> void
 Spillgebees.Blazor.Map.SgbMap.OnMapClick.get -> Microsoft.AspNetCore.Components.EventCallback<Spillgebees.Blazor.Map.MapClickEventArgs!>
 Spillgebees.Blazor.Map.SgbMap.OnMapClick.set -> void
 Spillgebees.Blazor.Map.SgbMap.OnMapError.get -> Microsoft.AspNetCore.Components.EventCallback<System.Exception!>
@@ -1290,6 +1315,7 @@ Spillgebees.Blazor.Map.SgbMap.Styles.get -> System.Collections.Generic.IReadOnly
 Spillgebees.Blazor.Map.SgbMap.Styles.set -> void
 Spillgebees.Blazor.Map.SgbMap.Theme.get -> Spillgebees.Blazor.Map.MapTheme
 Spillgebees.Blazor.Map.SgbMap.Theme.set -> void
+Spillgebees.Blazor.Map.SgbMap.ToggleFullscreenAsync() -> System.Threading.Tasks.Task!
 Spillgebees.Blazor.Map.SgbMap.WebFonts.get -> System.Collections.Generic.IReadOnlyList<string!>?
 Spillgebees.Blazor.Map.SgbMap.WebFonts.set -> void
 Spillgebees.Blazor.Map.SgbMap.Width.get -> string!


### PR DESCRIPTION
Closes: #163 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fullscreen control customization, including configurable enter/exit SVG icons and accessible titles/labels.
  * Center control now supports a custom SVG icon.
  * Map fullscreen is now observable and controllable via `IsFullscreen`, `OnFullscreenChanged`, `EnterFullscreenAsync`, `ExitFullscreenAsync`, and `ToggleFullscreenAsync`.
  * Added a pseudo-fullscreen fallback mode for environments without native Fullscreen support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->