### PR TITLE
🐛  fix `Height="100%"` regression

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/src/styles.scss
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles.scss
@@ -1,6 +1,10 @@
 @use "maplibre-gl/dist/maplibre-gl.css";
 
 // base container
+.sgb-map-root {
+  display: contents;
+}
+
 .sgb-map-container {
   // mirror maplibregl-map's critical layout properties so they survive
   // Blazor's class attribute re-renders (which can strip maplibregl-map).

--- a/src/Spillgebees.Blazor.Map.Assets/tests/browser/integration/engine-percent-sizing.spec.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/tests/browser/integration/engine-percent-sizing.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+const PAGE_ROUTE = "/engine-percent-sizing-functional-test";
+
+test.describe("engine percent sizing", () => {
+  test("Height and Width 100 percent fill a fixed-size parent", async ({ page }) => {
+    // arrange
+    await page.goto(PAGE_ROUTE, { waitUntil: "domcontentloaded" });
+    const parent = page.getByTestId("percent-map-parent");
+    const map = page.locator(".sgb-map-container");
+
+    // act
+    await expect(map).toBeAttached({ timeout: 60000 });
+
+    // assert
+    await expect
+      .poll(() => parent.boundingBox(), { timeout: 60000 })
+      .toMatchObject({
+        width: 640,
+        height: 360,
+      });
+    await expect
+      .poll(() => map.boundingBox(), { timeout: 60000 })
+      .toMatchObject({
+        width: 640,
+        height: 360,
+      });
+  });
+
+  test("root wrapper does not create a sizing boundary", async ({ page }) => {
+    // arrange
+    await page.goto(PAGE_ROUTE, { waitUntil: "domcontentloaded" });
+    const root = page.locator(".sgb-map-root");
+
+    // act
+    await expect(root).toBeAttached({ timeout: 60000 });
+    const display = await root.evaluate((element) => getComputedStyle(element).display);
+
+    // assert
+    expect(display).toBe("contents");
+  });
+});

--- a/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EnginePercentSizingFunctionalTest.razor
+++ b/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EnginePercentSizingFunctionalTest.razor
@@ -1,0 +1,23 @@
+@page "/engine-percent-sizing-functional-test"
+
+<main class="e2e-shell">
+    <h1>Engine percent sizing functional test</h1>
+    <p>Percent-sized maps should fill a fixed-size parent.</p>
+
+    <div data-testid="percent-map-parent" style="width: 640px; height: 360px; outline: 1px solid #94a3b8;">
+        <SgbMap Style="@_baseStyle"
+                Center="@(new Coordinate(49.61, 6.14))"
+                Zoom="12"
+                Height="100%"
+                Width="100%" />
+    </div>
+</main>
+
+@code {
+    private static readonly MapStyle _baseStyle = MapStyle
+        .FromRasterUrl(
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4YWMDAAMQAUEiFmcFAAAAAElFTkSuQmCC",
+            "base"
+        )
+        .WithId("base");
+}

--- a/src/Spillgebees.Blazor.Map.Tests/Engine/MapFeatureCoordinatorTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Engine/MapFeatureCoordinatorTests.cs
@@ -1,7 +1,7 @@
+using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.JSInterop;
 using Spillgebees.Blazor.Map.Engine;
-using System.Text.Json;
 
 namespace Spillgebees.Blazor.Map.Tests.Engine;
 
@@ -104,19 +104,26 @@ public class MapFeatureCoordinatorTests
             circles: [BuildCircle("c1")],
             polylines: [BuildPolyline("p1")]
         );
-        await Task.Yield();
+        await WaitForQuiescenceAsync(
+            js,
+            snapshot =>
+                DescribeAppliedOps(snapshot).Contains("marker.set:m1") && SetSourceDataSources(snapshot).Count >= 2
+        );
 
         // assert
-        DescribeAppliedOps(js)
+        var snapshot = js.Snapshot();
+
+        DescribeAppliedOps(snapshot)
             .Should()
-            .Equal(
+            .ContainInOrder(
                 "source.add:sgb-polylines-source",
                 "layer.add:sgb-polylines-layer",
                 "source.add:sgb-circles-source",
                 "layer.add:sgb-circles-layer",
                 "marker.set:m1"
             );
-        SetSourceDataSources(js).Should().Equal("sgb-polylines-source", "sgb-circles-source");
+        DescribeAppliedOps(snapshot).Should().ContainSingle(op => op == "marker.set:m1");
+        SetSourceDataSources(snapshot).Take(2).Should().Equal("sgb-polylines-source", "sgb-circles-source");
     }
 
     [Test]
@@ -129,8 +136,15 @@ public class MapFeatureCoordinatorTests
         coordinator.SetCircles("owner", [BuildCircle("c1")]);
         coordinator.SetPolylines("owner", [BuildPolyline("p1")]);
 
+        await WaitForQuiescenceAsync(
+            js,
+            snapshot =>
+                DescribeAppliedOps(snapshot).Contains("layer.add:sgb-polylines-layer")
+                && DescribeAppliedOps(snapshot).Contains("layer.add:sgb-circles-layer")
+        );
+
         // assert
-        DescribeAppliedOps(js)
+        DescribeAppliedOps(js.Snapshot())
             .Should()
             .ContainInOrder("layer.add:sgb-polylines-layer", "layer.add:sgb-circles-layer");
     }
@@ -173,47 +187,101 @@ public class MapFeatureCoordinatorTests
         );
 
     private static int CountSourceDataCalls(RecordingJsRuntime js) =>
-        js.Identifiers.Count(identifier => identifier == SetSourceDataIdentifier);
+        js.Snapshot().Count(call => call.Identifier == SetSourceDataIdentifier);
 
-    private static IReadOnlyList<string> DescribeAppliedOps(RecordingJsRuntime js)
+    private static IReadOnlyList<string> DescribeAppliedOps(IReadOnlyList<Invocation> invocations)
     {
         var described = new List<string>();
-        foreach (var invocation in js.Invocations.Where(call => call.Identifier == ApplyOpsIdentifier))
+        foreach (var invocation in invocations.Where(call => call.Identifier == ApplyOpsIdentifier))
         {
             using var document = JsonDocument.Parse((string)invocation.Args[1]!);
             described.AddRange(
-                document.RootElement.EnumerateArray().Select(op =>
-                {
-                    var opName = op.GetProperty("op").GetString();
-                    return opName switch
+                document
+                    .RootElement.EnumerateArray()
+                    .Select(op =>
                     {
-                        "marker.set" => $"marker.set:{op.GetProperty("marker").GetProperty("id").GetString()}",
-                        _ => $"{opName}:{op.GetProperty("id").GetString()}",
-                    };
-                })
+                        var opName = op.GetProperty("op").GetString();
+                        return opName switch
+                        {
+                            "marker.set" => $"marker.set:{op.GetProperty("marker").GetProperty("id").GetString()}",
+                            _ => $"{opName}:{op.GetProperty("id").GetString()}",
+                        };
+                    })
             );
         }
 
         return described;
     }
 
-    private static IReadOnlyList<string> SetSourceDataSources(RecordingJsRuntime js) =>
-        js.Invocations
+    private static IReadOnlyList<string> SetSourceDataSources(IReadOnlyList<Invocation> invocations) =>
+        invocations
             .Where(call => call.Identifier == SetSourceDataIdentifier)
             .Select(call => (string)call.Args[1]!)
             .ToArray();
+
+    private static async Task WaitForQuiescenceAsync(
+        RecordingJsRuntime js,
+        Func<IReadOnlyList<Invocation>, bool> isReadyToAssert
+    )
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var stablePolls = 0;
+        var previousCount = -1;
+        while (!timeout.IsCancellationRequested)
+        {
+            var snapshot = js.Snapshot();
+            var count = snapshot.Count;
+            if (count == previousCount)
+            {
+                stablePolls++;
+                if (stablePolls == 3 && isReadyToAssert(snapshot))
+                {
+                    return;
+                }
+            }
+            else
+            {
+                previousCount = count;
+                stablePolls = 0;
+            }
+
+            try
+            {
+                await Task.Delay(1, timeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        var finalSnapshot = js.Snapshot();
+        stablePolls.Should().Be(3, "the channel should become quiescent before assertions run");
+        isReadyToAssert(finalSnapshot).Should().BeTrue("the expected calls should be recorded before assertions run");
+    }
 
     private sealed record Invocation(string Identifier, object?[] Args);
 
     private sealed class RecordingJsRuntime : IJSRuntime
     {
-        public List<string> Identifiers { get; } = [];
-        public List<Invocation> Invocations { get; } = [];
+        private readonly Lock _lock = new();
+        private readonly List<Invocation> _invocations = [];
+
+        public IReadOnlyList<Invocation> Snapshot()
+        {
+            lock (_lock)
+            {
+                return _invocations.ToArray();
+            }
+        }
 
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
         {
-            Identifiers.Add(identifier);
-            Invocations.Add(new Invocation(identifier, args ?? []));
+            lock (_lock)
+            {
+                _invocations.Add(new Invocation(identifier, args ?? []));
+            }
+
             return ValueTask.FromResult(default(TValue)!);
         }
 


### PR DESCRIPTION
Closes: #173 

There was a regression with the performance rewrite that caused the `Height="100%"` use-case to no longer work as before, despite the parent having a proper size.

Also fixed flaky tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed map sizing inside percentage-based layouts so maps now fill their parent container correctly.
  * Improved root container behavior so it no longer affects page layout, helping map embeds render as expected in fixed-size sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->