### PR TITLE
🐛  fix display item AND logic not working as expected

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/bootstrap.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/bootstrap.ts
@@ -654,7 +654,11 @@ function toEngineMap(
     resolveComposedLayer: (styleId, layerId) => {
       const registration = window.Spillgebees.Map?.composedStyleLayerIds?.get(map)?.get(`${styleId}\u0000${layerId}`);
       return registration
-        ? { layerId: registration.runtimeLayerId, visible: registration.originalVisible ?? true }
+        ? {
+            layerId: registration.runtimeLayerId,
+            visible: registration.originalVisible ?? true,
+            filter: registration.originalFilter,
+          }
         : null;
     },
     listComposedLayers: (styleId) => {
@@ -668,6 +672,7 @@ function toEngineMap(
         .map((registration) => ({
           layerId: registration.runtimeLayerId,
           visible: registration.originalVisible ?? true,
+          filter: registration.originalFilter,
         }));
     },
   };

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.test.ts
@@ -16,7 +16,10 @@ interface Harness {
   log: string[];
   sources: Map<string, SourceStub>;
   layers: Map<string, { spec: Record<string, unknown>; beforeId: string | undefined }>;
-  composedLayers: Map<string, { runtimeLayerId: string; originalVisible: boolean }>;
+  composedLayers: Map<
+    string,
+    { runtimeLayerId: string; originalVisible: boolean; originalFilter: unknown | undefined }
+  >;
   featureStates: { source: string; id: number | string; state: Record<string, unknown> }[];
   events: EngineEvent[];
   errors: unknown[];
@@ -31,7 +34,10 @@ function createHarness(options: { sourcesSupportUpdateData?: boolean } = {}): Ha
   const log: string[] = [];
   const sources = new Map<string, SourceStub>();
   const layers = new Map<string, { spec: Record<string, unknown>; beforeId: string | undefined }>();
-  const composedLayers = new Map<string, { runtimeLayerId: string; originalVisible: boolean }>();
+  const composedLayers = new Map<
+    string,
+    { runtimeLayerId: string; originalVisible: boolean; originalFilter: unknown | undefined }
+  >();
   const featureStates: Harness["featureStates"] = [];
   const events: EngineEvent[] = [];
   const errors: unknown[] = [];
@@ -123,12 +129,18 @@ function createHarness(options: { sourcesSupportUpdateData?: boolean } = {}): Ha
     listStyleLayers: () => [...layers.values()].map((layer) => layer.spec as { id: string }),
     resolveComposedLayer: (styleId, layerId) => {
       const layer = composedLayers.get(`${styleId}\u0000${layerId}`);
-      return layer ? { layerId: layer.runtimeLayerId, visible: layer.originalVisible } : null;
+      return layer
+        ? { layerId: layer.runtimeLayerId, visible: layer.originalVisible, filter: layer.originalFilter }
+        : null;
     },
     listComposedLayers: (styleId) =>
       [...composedLayers.entries()]
         .filter(([key]) => key.startsWith(`${styleId}\u0000`))
-        .map(([, layer]) => ({ layerId: layer.runtimeLayerId, visible: layer.originalVisible })),
+        .map(([, layer]) => ({
+          layerId: layer.runtimeLayerId,
+          visible: layer.originalVisible,
+          filter: layer.originalFilter,
+        })),
     setMarker(marker) {
       log.push(`setMarker:${marker.id}`);
     },
@@ -766,6 +778,7 @@ describe("replay", () => {
     harness.composedLayers.set("railway\u0000railway-lifecycle-construction", {
       runtimeLayerId: "sgb-overlay-style-railway-railway-lifecycle-construction",
       originalVisible: true,
+      originalFilter: undefined,
     });
     harness.resetLog();
 

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/runtime.ts
@@ -100,8 +100,11 @@ export interface EngineMap {
   /** All layers of the current style (including engine-managed ones; the runtime filters). */
   listStyleLayers(): { id: string; layout?: { visibility?: string }; filter?: unknown; metadata?: unknown }[];
   /** Composed overlay-style layer lookups (styles/composition.ts registry). */
-  resolveComposedLayer(styleId: string, layerId: string): { layerId: string; visible: boolean } | null;
-  listComposedLayers(styleId: string): { layerId: string; visible: boolean }[];
+  resolveComposedLayer(
+    styleId: string,
+    layerId: string,
+  ): { layerId: string; visible: boolean; filter: unknown | undefined } | null;
+  listComposedLayers(styleId: string): { layerId: string; visible: boolean; filter: unknown | undefined }[];
 }
 
 interface GeoJsonSourceLike {

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.test.ts
@@ -3,7 +3,7 @@ import { composeDisplayFilter, createVisibilityController, styleLayerInfo, type 
 
 interface HostOptions {
   styleLayers?: ReturnType<typeof styleLayerInfo>[];
-  composed?: Record<string, { layerId: string; visible: boolean }[]>;
+  composed?: Record<string, { layerId: string; visible: boolean; filter: unknown | undefined }[]>;
 }
 
 const overlayStyleId = "railway";
@@ -38,6 +38,7 @@ function composedOverlayLayer(layer: ReturnType<typeof railwayLifecycleProposedL
   return {
     layerId: `sgb-overlay-style-${overlayStyleId}-${layer.id}`,
     visible: layer.layout.visibility !== "none",
+    filter: layer.filter,
   };
 }
 
@@ -129,7 +130,7 @@ describe("visibility controller", () => {
 
   it("prefers composed overlay-style layers over base style layers", () => {
     const { host, visibilityCalls } = createHost({
-      composed: { railway: [{ layerId: "sgb-overlay-style-railway-tracks", visible: true }] },
+      composed: { railway: [{ layerId: "sgb-overlay-style-railway-tracks", visible: true, filter: undefined }] },
     });
     const controller = createVisibilityController(host);
 
@@ -158,8 +159,8 @@ describe("visibility controller", () => {
       const { host, visibilityCalls } = createHost({
         composed: {
           railway: [
-            { layerId: "sgb-overlay-style-railway-railway-lifecycle-construction", visible: true },
-            { layerId: "sgb-overlay-style-railway-railway-switches", visible: true },
+            { layerId: "sgb-overlay-style-railway-railway-lifecycle-construction", visible: true, filter: undefined },
+            { layerId: "sgb-overlay-style-railway-railway-switches", visible: true, filter: undefined },
           ],
         },
       });
@@ -242,6 +243,34 @@ describe("visibility controller", () => {
     expect(filterCalls).toEqual([
       ["rail", ["all", ["has", "rail"], ["!", ["==", "type", "express"]]]],
       ["rail", ["has", "rail"]],
+    ]);
+  });
+
+  it("captures and restores composed overlay layer baseline filters", () => {
+    // arrange
+    const lifecycleLayer = railwayLifecycleProposedLayer();
+    const { host, filterCalls } = createHost({
+      composed: { [overlayStyleId]: [composedOverlayLayer(lifecycleLayer)] },
+    });
+    const controller = createVisibilityController(host);
+    const target = {
+      kind: "styleLayerFeatures" as const,
+      styleId: overlayStyleId,
+      layerIds: [lifecycleLayer.id],
+      filter: ["==", ["get", "status"], "planned"],
+    };
+
+    // act
+    controller.setGroup("planned-corridor", false, [target]);
+    controller.setGroup("planned-corridor", true, [target]);
+
+    // assert
+    expect(filterCalls).toEqual([
+      [
+        "sgb-overlay-style-railway-railway-lifecycle-proposed",
+        ["all", lifecycleLayer.filter, ["!", ["==", ["get", "status"], "planned"]]],
+      ],
+      ["sgb-overlay-style-railway-railway-lifecycle-proposed", lifecycleLayer.filter],
     ]);
   });
 

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.test.ts
@@ -6,6 +6,41 @@ interface HostOptions {
   composed?: Record<string, { layerId: string; visible: boolean }[]>;
 }
 
+const overlayStyleId = "railway";
+
+function railwayLifecycleProposedLayer(layoutVisibility?: "visible" | "none") {
+  return {
+    id: "railway-lifecycle-proposed",
+    type: "line",
+    source: "railway",
+    "source-layer": "railway_lines_lifecycle",
+    minzoom: 10,
+    metadata: { group: "lifecycle" },
+    filter: [
+      "all",
+      ["==", ["get", "railway"], "proposed"],
+      ["!", ["in", ["coalesce", ["get", "railway"], ""], ["literal", ["tram", "light_rail"]]]],
+    ],
+    layout: {
+      "line-join": "round",
+      "line-cap": "butt",
+      ...(layoutVisibility ? { visibility: layoutVisibility } : {}),
+    },
+    paint: {
+      "line-color": "#ca8a04",
+      "line-width": 2,
+      "line-opacity": 0.9,
+    },
+  };
+}
+
+function composedOverlayLayer(layer: ReturnType<typeof railwayLifecycleProposedLayer>) {
+  return {
+    layerId: `sgb-overlay-style-${overlayStyleId}-${layer.id}`,
+    visible: layer.layout.visibility !== "none",
+  };
+}
+
 function createHost(options: HostOptions = {}) {
   const visibilityCalls: [string, boolean][] = [];
   const filterCalls: [string, unknown][] = [];
@@ -154,6 +189,39 @@ describe("visibility controller", () => {
       ["hidden-by-style", false],
       ["hidden-by-style", false],
     ]);
+  });
+
+  it("keeps a composed overlay layer hidden when its original style visibility is none", () => {
+    // arrange
+    const lifecycleLayer = railwayLifecycleProposedLayer("none");
+    const { host, visibilityCalls } = createHost({
+      composed: { [overlayStyleId]: [composedOverlayLayer(lifecycleLayer)] },
+    });
+    const controller = createVisibilityController(host);
+
+    // act
+    controller.setGroup("whole-overlay", true, [{ kind: "styleLayer", styleId: overlayStyleId, layerIds: [] }]);
+
+    // assert
+    expect(visibilityCalls).toEqual([["sgb-overlay-style-railway-railway-lifecycle-proposed", false]]);
+  });
+
+  it("ANDs broad composed overlay visibility with a narrower hidden lifecycle layer target", () => {
+    // arrange
+    const lifecycleLayer = railwayLifecycleProposedLayer();
+    const { host, visibilityCalls } = createHost({
+      composed: { [overlayStyleId]: [composedOverlayLayer(lifecycleLayer)] },
+    });
+    const controller = createVisibilityController(host);
+
+    // act
+    controller.setGroup("lifecycle", false, [
+      { kind: "styleLayer", styleId: overlayStyleId, layerIds: [lifecycleLayer.id] },
+    ]);
+    controller.setGroup("whole-overlay", true, [{ kind: "styleLayer", styleId: overlayStyleId, layerIds: [] }]);
+
+    // assert
+    expect(new Map(visibilityCalls).get("sgb-overlay-style-railway-railway-lifecycle-proposed")).toBe(false);
   });
 
   it("captures and restores style layer baseline filters", () => {

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.ts
@@ -97,13 +97,16 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
   const styleBaselineFilters = new Map<string, unknown>();
   /** Original visibility of style layers, captured on first resolution. */
   const styleOriginalVisible = new Map<string, boolean>();
+  /** Original visibility of composed overlay layers, captured on first resolution. */
+  const composedOriginalVisible = new Map<string, boolean>();
   /** Layers currently carrying a composed (baseline + hidden) filter. */
   const composedFilterLayers = new Set<string>();
 
   function resolveStyleLayer(styleId: string, layerId: string): ResolvedLayer | null {
     const composed = host.resolveComposedLayer(styleId, layerId);
     if (composed) {
-      return { layerId: composed.layerId, originalVisible: composed.visible };
+      rememberComposedLayer(composed);
+      return { layerId: composed.layerId, originalVisible: composedOriginalVisible.get(composed.layerId) ?? true };
     }
 
     const styleLayer = host.listStyleLayers().find((layer) => layer.id === layerId);
@@ -125,6 +128,12 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
     }
   }
 
+  function rememberComposedLayer(layer: { layerId: string; visible: boolean }): void {
+    if (!composedOriginalVisible.has(layer.layerId)) {
+      composedOriginalVisible.set(layer.layerId, layer.visible);
+    }
+  }
+
   function resolveTarget(target: VisibilityTarget): ResolvedLayer[] {
     switch (target.kind) {
       case "runtimeLayer":
@@ -136,7 +145,10 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
         if (target.layerIds.length === 0) {
           const composed = host.listComposedLayers(target.styleId);
           if (composed.length > 0) {
-            return composed.map((layer) => ({ layerId: layer.layerId, originalVisible: layer.visible }));
+            return composed.map((layer) => {
+              rememberComposedLayer(layer);
+              return { layerId: layer.layerId, originalVisible: composedOriginalVisible.get(layer.layerId) ?? true };
+            });
           }
 
           return host.listStyleLayers().map((layer) => {
@@ -210,7 +222,7 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
       return runtime.visible;
     }
 
-    return styleOriginalVisible.get(layerId) ?? true;
+    return composedOriginalVisible.get(layerId) ?? styleOriginalVisible.get(layerId) ?? true;
   }
 
   function applyVisibilityFor(layerId: string): void {
@@ -386,6 +398,7 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
       // the new style starts fresh: recapture originals lazily
       styleBaselineFilters.clear();
       styleOriginalVisible.clear();
+      composedOriginalVisible.clear();
       composedFilterLayers.clear();
       applyTargets(allRegisteredTargets());
     },

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/visibility.ts
@@ -18,6 +18,12 @@ export interface StyleLayerInfo {
   tags: string[];
 }
 
+export interface ComposedLayerInfo {
+  layerId: string;
+  visible: boolean;
+  filter: unknown | undefined;
+}
+
 /** Map surface + engine lookups the controller needs; injectable for tests. */
 export interface VisibilityHost {
   getRuntimeLayer(layerId: string): { visible: boolean } | null;
@@ -25,8 +31,8 @@ export interface VisibilityHost {
   /** Layers of the base style (excluding engine-managed runtime layers). */
   listStyleLayers(): StyleLayerInfo[];
   /** Resolves a composed overlay-style layer to its runtime id, if composed. */
-  resolveComposedLayer(styleId: string, layerId: string): { layerId: string; visible: boolean } | null;
-  listComposedLayers(styleId: string): { layerId: string; visible: boolean }[];
+  resolveComposedLayer(styleId: string, layerId: string): ComposedLayerInfo | null;
+  listComposedLayers(styleId: string): ComposedLayerInfo[];
   setLayerVisibility(layerId: string, visible: boolean): void;
   setLayerFilter(layerId: string, filter: unknown): void;
   hasLayer(layerId: string): boolean;
@@ -99,6 +105,8 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
   const styleOriginalVisible = new Map<string, boolean>();
   /** Original visibility of composed overlay layers, captured on first resolution. */
   const composedOriginalVisible = new Map<string, boolean>();
+  /** Original filters of composed overlay layers, captured on first resolution. */
+  const composedBaselineFilters = new Map<string, unknown>();
   /** Layers currently carrying a composed (baseline + hidden) filter. */
   const composedFilterLayers = new Set<string>();
 
@@ -128,9 +136,13 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
     }
   }
 
-  function rememberComposedLayer(layer: { layerId: string; visible: boolean }): void {
+  function rememberComposedLayer(layer: ComposedLayerInfo): void {
     if (!composedOriginalVisible.has(layer.layerId)) {
       composedOriginalVisible.set(layer.layerId, layer.visible);
+    }
+
+    if (!composedBaselineFilters.has(layer.layerId)) {
+      composedBaselineFilters.set(layer.layerId, layer.filter ?? null);
     }
   }
 
@@ -286,7 +298,9 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
 
     const baseline = host.getRuntimeLayer(layerId)
       ? host.getRuntimeBaselineFilter(layerId)
-      : styleBaselineFilters.get(layerId);
+      : composedBaselineFilters.has(layerId)
+        ? composedBaselineFilters.get(layerId)
+        : styleBaselineFilters.get(layerId);
     if (hidden.length === 0) {
       composedFilterLayers.delete(layerId);
       host.setLayerFilter(layerId, baseline ?? null);
@@ -399,6 +413,7 @@ export function createVisibilityController(host: VisibilityHost): VisibilityCont
       styleBaselineFilters.clear();
       styleOriginalVisible.clear();
       composedOriginalVisible.clear();
+      composedBaselineFilters.clear();
       composedFilterLayers.clear();
       applyTargets(allRegisteredTargets());
     },

--- a/src/Spillgebees.Blazor.Map.Assets/src/interfaces/spillgebees.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/interfaces/spillgebees.ts
@@ -7,6 +7,7 @@ export interface ComposedStyleLayerRegistration {
   styleId: string;
   originalLayerId: string;
   originalVisible?: boolean;
+  originalFilter: unknown | undefined;
 }
 
 export interface OverlayStyleRequestOptions {

--- a/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.test.ts
@@ -429,4 +429,40 @@ describe("applyOverlayStyles", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(1, "https://example.com/a.json", { referrerPolicy: "origin" });
     expect(fetchMock).toHaveBeenNthCalledWith(2, "https://example.com/b.json", { referrerPolicy: "no-referrer" });
   });
+
+  it("should register composed layer baseline filters without cloning", async () => {
+    // arrange
+    const map = {
+      getSource: vi.fn().mockReturnValue(undefined),
+      addSource: vi.fn(),
+      hasImage: vi.fn().mockReturnValue(true),
+      getLayer: vi.fn().mockReturnValue(undefined),
+      addLayer: vi.fn(),
+    } as unknown as Parameters<typeof applyOverlayStyles>[0];
+    window.Spillgebees.Map.composedStyleLayerIds.set(map, new Map());
+    const filter = ["==", ["get", "railway"], "proposed"];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        url: "https://example.com/railway.json",
+        json: vi.fn().mockResolvedValue({
+          version: 8,
+          sources: {},
+          layers: [{ id: "railway-lifecycle-proposed", type: "line", filter }],
+        }),
+      }),
+    );
+
+    // act
+    await applyOverlayStyles(map, [
+      { styleId: "railway", url: "https://example.com/railway.json", referrerPolicy: null },
+    ]);
+
+    // assert
+    expect(
+      window.Spillgebees.Map.composedStyleLayerIds.get(map)?.get("railway\u0000railway-lifecycle-proposed")
+        ?.originalFilter,
+    ).toBe(filter);
+  });
 });

--- a/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/styles/composition.ts
@@ -56,6 +56,7 @@ export interface OverlayStyleState {
     originalLayerId: string;
     runtimeLayerId: string;
     originalVisible: boolean;
+    originalFilter: unknown;
   }>;
 }
 
@@ -81,6 +82,10 @@ function getOverlayMap(map: MapLibreMap): Map<string, OverlayStyleState> {
     appliedOverlays.set(map, overlays);
   }
   return overlays;
+}
+
+function layerFilter(layer: StyleSpecification["layers"][number]): unknown {
+  return "filter" in layer ? layer.filter : null;
 }
 
 /**
@@ -155,7 +160,16 @@ export async function applyOverlayStyles(
 }
 
 function registerComposedLayerIds(
-  store: Map<string, { runtimeLayerId: string; styleId: string; originalLayerId: string; originalVisible?: boolean }>,
+  store: Map<
+    string,
+    {
+      runtimeLayerId: string;
+      styleId: string;
+      originalLayerId: string;
+      originalVisible?: boolean;
+      originalFilter: unknown | undefined;
+    }
+  >,
   state: OverlayStyleState,
 ): void {
   for (const layer of state.composedLayerIds) {
@@ -295,6 +309,7 @@ async function mergeStyleIntoMap(
           originalLayerId: layer.id,
           runtimeLayerId: prefixedLayerId,
           originalVisible: layer.layout?.visibility !== "none",
+          originalFilter: layerFilter(layer),
         });
         continue;
       }
@@ -323,6 +338,7 @@ async function mergeStyleIntoMap(
           originalLayerId: layer.id,
           runtimeLayerId: prefixedLayerId,
           originalVisible: layer.layout?.visibility !== "none",
+          originalFilter: layerFilter(layer),
         });
       } catch (error) {
         // biome-ignore lint/suspicious/noConsole: library warning for developers

--- a/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineDisplayFunctionalTest.razor
+++ b/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineDisplayFunctionalTest.razor
@@ -9,6 +9,9 @@
         <button type="button" data-testid="toggle-express" @onclick="@(() => _display.Toggle("express"))">Toggle express</button>
         <button type="button" data-testid="toggle-display-overlay-style" @onclick="@(() => _display.Toggle("overlay-style"))">Toggle display overlay style</button>
         <button type="button" data-testid="toggle-display-overlay-secondary" @onclick="@(() => _display.Toggle("overlay-secondary"))">Toggle display secondary</button>
+        <button type="button"
+                data-testid="toggle-planned-corridor"
+                @onclick="@(() => _display.Toggle("planned-corridor"))">Toggle planned corridor</button>
         <button type="button" data-testid="toggle-overlay" @onclick="ToggleOverlayAsync">Toggle overlay</button>
         <button type="button" data-testid="toggle-part" @onclick="TogglePartAsync">Toggle runtime part</button>
     </section>
@@ -20,7 +23,7 @@
 
     <div id="engine-display-frame" class="stress-map-frame">
         <SgbMap @ref="_map"
-                  Style="@BaseStyle"
+                  Style="@_baseStyle"
                   Display="@_display"
                   Center="@(new Coordinate(49.61, 6.14))"
                   Zoom="12"
@@ -31,10 +34,12 @@
                 <CircleLayer Id="disp-points"
                                Radius="8"
                                Color="@("#dc2626")"
-                               Filter="@BaselineFilter" />
+                               Filter="@_baselineFilter" />
             </GeoJsonSource>
-            <MapOverlay Id="annotations" Label="Annotations" Style="@OverlayStyle">
-                <MapOverlayPart Id="composed" Label="Composed" LayerIds="@(new[] { "overlay-circle" })" />
+            <MapOverlay Id="annotations" Label="Annotations" Style="@_overlayStyle">
+                <MapOverlayPart Id="composed"
+                                Label="Composed"
+                                LayerIds="@(["overlay-circle", "planned-corridor-line"])" />
                 <MapOverlayPart Id="runtime" Label="Runtime">
                     <GeoJsonSource Id="overlay-runtime" Data="@RuntimePartDataJson">
                         <CircleLayer Id="overlay-runtime-circle" Radius="6" Color="@("#16a34a")" />
@@ -46,16 +51,16 @@
 </main>
 
 @code {
-    private static readonly MapStyle BaseStyle = MapStyle
+    private static readonly MapStyle _baseStyle = MapStyle
         .FromRasterUrl(
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4YWMDAAMQAUEiFmcFAAAAAElFTkSuQmCC",
             "base"
         )
         .WithId("base");
 
-    private static readonly MapStyle OverlayStyle = MapStyle.FromUrl("/test-overlay-style.json").WithId("annotations");
+    private static readonly MapStyle _overlayStyle = MapStyle.FromUrl("/test-overlay-style.json").WithId("annotations");
 
-    private static readonly object BaselineFilter = new object[] { "has", "name" };
+    private static readonly object _baselineFilter = new object[] { "has", "name" };
 
     private const string DataJson = """
         {"type":"FeatureCollection","features":[
@@ -74,6 +79,12 @@
         [
             new MapDisplayItem("points", [MapDisplayTarget.RuntimeLayers("disp-points")], Label: "Points"),
             new MapDisplayItem("overlay-style", [MapDisplayTarget.StyleLayers("annotations")], Label: "Overlay style"),
+            new MapDisplayItem(
+                "planned-corridor",
+                [MapDisplayTarget.StyleLayers("annotations", "planned-corridor-line")],
+                IsOn: false,
+                Label: "Planned corridor"
+            ),
             new MapDisplayItem(
                 "overlay-secondary",
                 [MapDisplayTarget.StyleLayers("annotations", "overlay-secondary-circle")],

--- a/src/Spillgebees.Blazor.Map.IntegrationTests/wwwroot/test-overlay-style.json
+++ b/src/Spillgebees.Blazor.Map.IntegrationTests/wwwroot/test-overlay-style.json
@@ -15,6 +15,19 @@
                         "type": "Feature",
                         "geometry": { "type": "Point", "coordinates": [6.145, 49.61] },
                         "properties": { "name": "overlay-secondary-marker" }
+                    },
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [
+                                [6.105, 49.598],
+                                [6.125, 49.605],
+                                [6.15, 49.618],
+                                [6.172, 49.626]
+                            ]
+                        },
+                        "properties": { "name": "planned-corridor" }
                     }
                 ]
             }
@@ -34,6 +47,14 @@
             "source": "overlay-points",
             "filter": ["==", ["get", "name"], "overlay-secondary-marker"],
             "paint": { "circle-radius": 10, "circle-color": "#22c55e" }
+        },
+        {
+            "id": "planned-corridor-line",
+            "type": "line",
+            "source": "overlay-points",
+            "filter": ["==", ["get", "name"], "planned-corridor"],
+            "layout": { "line-join": "round", "line-cap": "round" },
+            "paint": { "line-color": "#f59e0b", "line-width": 5, "line-opacity": 0.9 }
         }
     ]
 }


### PR DESCRIPTION
Fixes an issue where creating a base layer display item on top of a toggle for specific layers of the same base layer would not apply correctly.

I.e.:

```pseudo
display item for base layer: on
display item for some layer within that base layer: off
result: some layer -> on
```

Now:

```pseudo
display item for base layer: on
display item for some layer within that base layer: off
result: some layer -> off
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “planned corridor” map overlay that can be toggled on and off, with its own rendered line style and composed targeting.

* **Bug Fixes**
  * Improved composed overlay visibility so composed layers remain hidden when their source/target layers are hidden, and composed originals are preserved consistently.
  * Corrected composed overlay baseline filter handling, including proper filter combination and restoration after state toggles.

* **Tests**
  * Expanded coverage for composed overlay visibility and baseline filter behavior, plus updated integration/JSON fixtures for the planned corridor overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->