### PR TITLE
✨  add follow camera tracking animation

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.test.ts
@@ -284,6 +284,128 @@ describe("follow controller", () => {
       expect(options?.pitch).toBe(30);
     });
 
+    it("uses instant tracking moves by default", () => {
+      // arrange
+      fake.setEntity(6, 49);
+      fake.controller.apply(follow({ animation: { durationMs: 0 } }));
+      fake.step();
+
+      // act
+      fake.setEntity(6.3, 49.3);
+      fake.step();
+
+      // assert
+      expect(fake.lastEaseTo()?.duration).toBe(0);
+      expect(fake.lastEaseTo()?.easing).toBeUndefined();
+    });
+
+    it("applies configured ease-in-out tracking animation without overriding native easing", () => {
+      // arrange
+      fake.setEntity(6, 49);
+      fake.controller.apply(
+        follow({
+          camera: camera({ trackingAnimation: { durationMs: 250, easing: "easeInOut" } }),
+          animation: { durationMs: 0 },
+        }),
+      );
+      fake.step();
+
+      // act
+      fake.setEntity(6.3, 49.3);
+      fake.step();
+
+      // assert
+      expect(fake.lastEaseTo()?.duration).toBe(250);
+      expect(fake.lastEaseTo()?.easing).toBeUndefined();
+    });
+
+    it("keeps configured tracking animation for jumped updates after idle", () => {
+      // arrange
+      fake.setEntity(6, 49);
+      fake.controller.apply(
+        follow({
+          camera: camera({ trackingAnimation: { durationMs: 250, easing: "easeInOut" } }),
+          animation: { durationMs: 0 },
+        }),
+      );
+      fake.step(0);
+
+      // act
+      fake.setEntity(6.3, 49.3);
+      fake.step(1000);
+
+      // assert
+      expect(fake.lastEaseTo()?.duration).toBe(250);
+      expect(fake.lastEaseTo()?.easing).toBeUndefined();
+    });
+
+    it("does not restart configured tracking animation for continuous updates", () => {
+      // arrange
+      fake.setEntity(6, 49);
+      fake.controller.apply(
+        follow({
+          camera: camera({ trackingAnimation: { durationMs: 250, easing: "easeInOut" } }),
+          animation: { durationMs: 0 },
+        }),
+      );
+      fake.step(0);
+
+      // act
+      fake.setEntity(6.01, 49.01);
+      fake.step(16);
+      fake.setEntity(6.02, 49.02);
+      fake.step(32);
+
+      // assert
+      expect(fake.easeTo).toHaveBeenCalledTimes(3);
+      expect(fake.easeTo.mock.calls[1]?.[0].duration).toBe(0);
+      expect(fake.easeTo.mock.calls[2]?.[0].duration).toBe(0);
+    });
+
+    it("applies configured linear tracking animation", () => {
+      // arrange
+      fake.setEntity(6, 49);
+      fake.controller.apply(
+        follow({
+          camera: camera({ trackingAnimation: { durationMs: 250, easing: "linear" } }),
+          animation: { durationMs: 0 },
+        }),
+      );
+      fake.step();
+
+      // act
+      fake.setEntity(6.3, 49.3);
+      fake.step();
+
+      // assert
+      expect(fake.lastEaseTo()?.duration).toBe(250);
+      expect(typeof fake.lastEaseTo()?.easing).toBe("function");
+      expect((fake.lastEaseTo()?.easing as (t: number) => number)(0.5)).toBe(0.5);
+    });
+
+    it("keeps engage animation separate from tracking animation", () => {
+      // arrange
+      fake.setEntity(6, 49);
+      fake.controller.apply(
+        follow({
+          camera: camera({ trackingAnimation: { durationMs: 300, easing: "linear" } }),
+          animation: { durationMs: 700, easing: "easeInOut" },
+        }),
+      );
+
+      // act
+      fake.step(0);
+      const engageOptions = fake.lastEaseTo();
+      fake.setEntity(6.3, 49.3);
+      fake.step(800);
+
+      // assert
+      expect(engageOptions?.duration).toBe(700);
+      expect(engageOptions?.easing).toBeUndefined();
+      expect(fake.lastEaseTo()?.duration).toBe(300);
+      expect(typeof fake.lastEaseTo()?.easing).toBe("function");
+    });
+
     it("pauses tracking while the pointer is held, then resumes on release", () => {
       // arrange
       fake.setEntity(6, 49);

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.test.ts
@@ -339,6 +339,35 @@ describe("follow controller", () => {
       expect(fake.lastEaseTo()?.easing).toBeUndefined();
     });
 
+    it("keeps jumped tracking animation after stationary match-heading correction", () => {
+      // arrange
+      fake.setEntity(6, 49, 0);
+      fake.controller.apply(
+        follow({
+          camera: camera({
+            orientationMode: "anchored",
+            bearingSource: "matchheading",
+            trackingAnimation: { durationMs: 250, easing: "easeInOut" },
+          }),
+          animation: { durationMs: 0 },
+        }),
+      );
+      fake.step(0);
+
+      // act: heading drifts while parked, then the next frame carries a real jumped position update
+      fake.setEntity(6, 49, 90);
+      fake.step(1000);
+      fake.setEntity(6.3, 49.3, 90);
+      fake.step(1016);
+
+      // assert
+      expect(fake.easeTo).toHaveBeenCalledTimes(3);
+      expect(fake.easeTo.mock.calls[1]?.[0].center).toEqual([6, 49]);
+      expect(fake.easeTo.mock.calls[1]?.[0].duration).toBe(0);
+      expect(fake.lastEaseTo()?.center).toEqual([6.3, 49.3]);
+      expect(fake.lastEaseTo()?.duration).toBe(250);
+    });
+
     it("does not restart configured tracking animation for continuous updates", () => {
       // arrange
       fake.setEntity(6, 49);

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.ts
@@ -273,9 +273,11 @@ export function createFollowController(deps: FollowControllerDeps): FollowContro
 
     if (positionMoved || bearingConverging || zoomDrifted || pitchDrifted || bearingDrifted) {
       applyTrackMove(target, lng, lat, trackBearing, shouldAnimateTrackMove(target, now, positionMoved));
-      lastMoveAt = now;
-      lastLng = lng;
-      lastLat = lat;
+      if (positionMoved) {
+        lastMoveAt = now;
+        lastLng = lng;
+        lastLat = lat;
+      }
     }
 
     return true;

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/follow.ts
@@ -26,6 +26,7 @@ const MISSING_RESCAN_MS = 250;
 // How long tracking stays paused after a wheel tick. Wheel zoom has no end event, so we hold off the
 // recentre for a short window after the last notch (refreshed on each one) and resume once it settles.
 const WHEEL_PAUSE_MS = 400;
+const CONTINUOUS_TRACKING_FRAME_MS = 50;
 
 /** Why the engine cleared a follow, mirrored by the lowercase names of the .NET MapFollowChangeReason. */
 export type FollowClearReason = "userinteraction" | "featuremissing";
@@ -95,6 +96,8 @@ interface FollowTarget {
   // The engage move honours the requested easing. easeTo's native curve is already ease-in-out,
   // so we only override it for a linear request; the follow default (no animation) stays ease-in-out.
   linearEngage: boolean;
+  trackingAnimationMs: number;
+  linearTracking: boolean;
   interaction: FollowInteractionConfig;
 }
 
@@ -121,6 +124,7 @@ export function createFollowController(deps: FollowControllerDeps): FollowContro
   // paused (wheel has no press to hold, so it gets a grace window instead).
   let lastFrameNow = 0;
   let pausedUntil = 0;
+  let lastMoveAt = Number.NEGATIVE_INFINITY;
   let lastLng = Number.NaN;
   let lastLat = Number.NaN;
   // Resolved targets, fixed at engage. null zoom/pitch means that gesture's mode does not hold a target.
@@ -151,6 +155,8 @@ export function createFollowController(deps: FollowControllerDeps): FollowContro
       camera: op.camera ?? null,
       animationMs: op.animation?.durationMs ?? DEFAULT_ANIMATION_MS,
       linearEngage: op.animation?.easing === "linear",
+      trackingAnimationMs: op.camera?.trackingAnimation?.durationMs ?? 0,
+      linearTracking: op.camera?.trackingAnimation?.easing === "linear",
       interaction: op.interaction ?? DEFAULT_INTERACTION,
     };
     cachedIndex = null;
@@ -160,6 +166,7 @@ export function createFollowController(deps: FollowControllerDeps): FollowContro
     paused = false;
     lastFrameNow = 0;
     pausedUntil = 0;
+    lastMoveAt = Number.NEGATIVE_INFINITY;
     lastLng = Number.NaN;
     lastLat = Number.NaN;
     holdZoom = null;
@@ -221,6 +228,7 @@ export function createFollowController(deps: FollowControllerDeps): FollowContro
       applyEngageMove(target, lng, lat);
       hasEngaged = true;
       engageUntil = now + target.animationMs;
+      lastMoveAt = now;
       lastLng = lng;
       lastLat = lat;
       return true;
@@ -264,7 +272,8 @@ export function createFollowController(deps: FollowControllerDeps): FollowContro
       trackBearing != null && Math.abs(shortestAngleDelta(trackBearing, deps.map.getBearing())) > BEARING_EPSILON;
 
     if (positionMoved || bearingConverging || zoomDrifted || pitchDrifted || bearingDrifted) {
-      applyTrackMove(target, lng, lat, trackBearing);
+      applyTrackMove(target, lng, lat, trackBearing, shouldAnimateTrackMove(target, now, positionMoved));
+      lastMoveAt = now;
       lastLng = lng;
       lastLat = lat;
     }
@@ -353,8 +362,24 @@ export function createFollowController(deps: FollowControllerDeps): FollowContro
     deps.map.easeTo(options);
   }
 
-  function applyTrackMove(active: FollowTarget, lng: number, lat: number, bearing: number | undefined): void {
-    const options: Record<string, unknown> = { center: [lng, lat], duration: 0 };
+  function shouldAnimateTrackMove(active: FollowTarget, now: number, positionMoved: boolean): boolean {
+    // Interpolated entities update every frame. A non-zero easeTo duration would be cancelled and
+    // restarted on each frame, so only apply tracking ease after a short gap that marks a discrete jump.
+    return positionMoved && active.trackingAnimationMs > 0 && now - lastMoveAt >= CONTINUOUS_TRACKING_FRAME_MS;
+  }
+
+  function applyTrackMove(
+    active: FollowTarget,
+    lng: number,
+    lat: number,
+    bearing: number | undefined,
+    animate: boolean,
+  ): void {
+    const options: Record<string, unknown> = { center: [lng, lat], duration: animate ? active.trackingAnimationMs : 0 };
+
+    if (animate && active.linearTracking) {
+      options.easing = LINEAR_EASING;
+    }
 
     if (active.camera?.offset) {
       options.offset = [active.camera.offset.x, active.camera.offset.y];

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/ops.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/ops.ts
@@ -22,6 +22,7 @@ export interface FollowCameraConfig {
   bearingSource: "keepcurrent" | "fixed" | "matchheading";
   bearing?: number | null;
   offset?: { x: number; y: number } | null;
+  trackingAnimation?: AnimationConfig | null;
 }
 
 export interface FollowInteractionConfig {

--- a/src/Spillgebees.Blazor.Map.Assets/tests/browser/integration/engine-follow.spec.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/tests/browser/integration/engine-follow.spec.ts
@@ -98,6 +98,19 @@ test.describe("engine camera follow", () => {
     await expect.poll(() => centerLat(page), { timeout: 20000 }).toBeCloseTo(49.64, 2);
   });
 
+  test("eases tracking for jumped entity camera moves when configured", async ({ page }) => {
+    await openFixture(page);
+    await page.getByTestId("start-follow-tracking-animated").click();
+    await expect.poll(() => centerLng(page), { timeout: 20000 }).toBeCloseTo(6.14, 2);
+
+    await page.getByTestId("move-e1").click();
+
+    // Tracking animation is opt-in, so a jumped entity starts a camera transition instead of snapping.
+    await expect.poll(() => evaluateOnMap<boolean>(page, "return map.isMoving();"), { timeout: 5000 }).toBe(true);
+    await expect.poll(() => centerLng(page), { timeout: 20000 }).toBeCloseTo(6.19, 2);
+    await expect.poll(() => centerLat(page), { timeout: 20000 }).toBeCloseTo(49.64, 2);
+  });
+
   test("holds a fixed zoom, restoring it after the camera zooms away", async ({ page }) => {
     await openFixture(page);
     await page.getByTestId("start-follow-fixed-zoom").click();

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/CameraFollow/CameraFollowExample.razor
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/CameraFollow/CameraFollowExample.razor
@@ -75,6 +75,16 @@
                     <button type="button" class="sample-btn @(_offset == OffsetChoice.Right ? "active" : "")" aria-pressed="@(_offset == OffsetChoice.Right)" @onclick="@(() => SetOffset(OffsetChoice.Right))">Offset right</button>
                 </div>
             </div>
+
+            <div class="follow-field">
+                <span class="follow-field-label">Tracking</span>
+                <div class="follow-options">
+                    <button type="button" class="sample-btn @(_trackingAnimation == AnimationChoice.Instant ? "active" : "")" aria-pressed="@(_trackingAnimation == AnimationChoice.Instant)" @onclick="@(() => SetTrackingAnimation(AnimationChoice.Instant))">Instant</button>
+                    <button type="button" class="sample-btn @(_trackingAnimation == AnimationChoice.EaseInOut ? "active" : "")" aria-pressed="@(_trackingAnimation == AnimationChoice.EaseInOut)" @onclick="@(() => SetTrackingAnimation(AnimationChoice.EaseInOut))">Ease in-out</button>
+                    <button type="button" class="sample-btn @(_trackingAnimation == AnimationChoice.Linear ? "active" : "")" aria-pressed="@(_trackingAnimation == AnimationChoice.Linear)" @onclick="@(() => SetTrackingAnimation(AnimationChoice.Linear))">Linear</button>
+                </div>
+                <p class="follow-note">Camera tracking ease is intended for jumped updates. Continuous motion still recentres instantly so each frame does not restart the ease.</p>
+            </div>
         </section>
 
         <section class="follow-group">
@@ -86,6 +96,14 @@
                     <button type="button" class="sample-btn @(_animation == AnimationChoice.Instant ? "active" : "")" aria-pressed="@(_animation == AnimationChoice.Instant)" @onclick="@(() => SetAnimation(AnimationChoice.Instant))">Instant</button>
                     <button type="button" class="sample-btn @(_animation == AnimationChoice.EaseInOut ? "active" : "")" aria-pressed="@(_animation == AnimationChoice.EaseInOut)" @onclick="@(() => SetAnimation(AnimationChoice.EaseInOut))">Ease in-out</button>
                     <button type="button" class="sample-btn @(_animation == AnimationChoice.Linear ? "active" : "")" aria-pressed="@(_animation == AnimationChoice.Linear)" @onclick="@(() => SetAnimation(AnimationChoice.Linear))">Linear</button>
+                </div>
+            </div>
+
+            <div class="follow-field">
+                <span class="follow-field-label">Train motion</span>
+                <div class="follow-options">
+                    <button type="button" class="sample-btn @(_trainMotion == TrainMotionChoice.Ease ? "active" : "")" aria-pressed="@(_trainMotion == TrainMotionChoice.Ease)" @onclick="@(() => SetTrainMotion(TrainMotionChoice.Ease))">Ease</button>
+                    <button type="button" class="sample-btn @(_trainMotion == TrainMotionChoice.Jump ? "active" : "")" aria-pressed="@(_trainMotion == TrainMotionChoice.Jump)" @onclick="@(() => SetTrainMotion(TrainMotionChoice.Jump))">Jump</button>
                 </div>
             </div>
 
@@ -129,7 +147,7 @@
                                 Rotation="@(train => train.Heading)"
                                 Icon="@(train => $"follow-train-{train.Id}")"
                                 IconSize="1"
-                                Animate="@(TimeSpan.FromMilliseconds(1000))"
+                                Animate="@(_trainMotion == TrainMotionChoice.Ease ? TimeSpan.FromMilliseconds(1000) : null)"
                                 Interactive="true"
                                 OnClick="@(interaction => SelectTarget(interaction.Item.Id))" />
         </SgbMap>

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/CameraFollow/CameraFollowExample.razor.cs
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/CameraFollow/CameraFollowExample.razor.cs
@@ -21,6 +21,8 @@ public partial class CameraFollowExample : IAsyncDisposable
     private MapFollowBearingSource _bearingSource = MapFollowBearingSource.KeepCurrent;
     private OffsetChoice _offset = OffsetChoice.Centered;
     private AnimationChoice _animation = AnimationChoice.EaseInOut;
+    private AnimationChoice _trackingAnimation = AnimationChoice.Instant;
+    private TrainMotionChoice _trainMotion = TrainMotionChoice.Ease;
     private bool _clearOnPan = true;
     private bool _clearWhenMissing = true;
 
@@ -147,6 +149,14 @@ public partial class CameraFollowExample : IAsyncDisposable
         RebuildFollow();
     }
 
+    private void SetTrackingAnimation(AnimationChoice value)
+    {
+        _trackingAnimation = value;
+        RebuildFollow();
+    }
+
+    private void SetTrainMotion(TrainMotionChoice value) => _trainMotion = value;
+
     private void ToggleClearOnPan()
     {
         _clearOnPan = !_clearOnPan;
@@ -179,20 +189,24 @@ public partial class CameraFollowExample : IAsyncDisposable
                 Pitch: _pitch == PitchChoice.MaxTilt ? 60 : null,
                 BearingSource: _bearingSource,
                 Bearing: _bearingSource == MapFollowBearingSource.Fixed ? 90 : null,
-                Offset: _offset == OffsetChoice.Right ? new PixelPoint(140, 0) : null
+                Offset: _offset == OffsetChoice.Right ? new PixelPoint(140, 0) : null,
+                TrackingAnimation: ToAnimationOptions(_trackingAnimation)
             ),
-            Animation: _animation switch
-            {
-                AnimationChoice.Instant => new AnimationOptions(0),
-                AnimationChoice.Linear => new AnimationOptions(600, AnimationEasing.Linear),
-                _ => new AnimationOptions(600, AnimationEasing.EaseInOut),
-            },
+            Animation: ToAnimationOptions(_animation) ?? new AnimationOptions(0),
             Interaction: new MapFollowInteractionOptions(
                 ClearOnUserPan: _clearOnPan,
                 ClearWhenFeatureMissing: _clearWhenMissing
             )
         );
     }
+
+    private static AnimationOptions? ToAnimationOptions(AnimationChoice value) =>
+        value switch
+        {
+            AnimationChoice.Instant => null,
+            AnimationChoice.Linear => new AnimationOptions(600, AnimationEasing.Linear),
+            _ => new AnimationOptions(600, AnimationEasing.EaseInOut),
+        };
 
     private void HandleFollowChanged(MapFollowChangedEventArgs args)
     {
@@ -255,5 +269,11 @@ public partial class CameraFollowExample : IAsyncDisposable
         Instant,
         EaseInOut,
         Linear,
+    }
+
+    private enum TrainMotionChoice
+    {
+        Ease,
+        Jump,
     }
 }

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/CameraFollow/CameraFollowExample.razor.cs
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/CameraFollow/CameraFollowExample.razor.cs
@@ -230,28 +230,6 @@ public partial class CameraFollowExample : IAsyncDisposable
             </svg>
             """;
 
-    public async ValueTask DisposeAsync()
-    {
-        GC.SuppressFinalize(this);
-
-        if (_cts is not null)
-        {
-            await _cts.CancelAsync();
-            _cts.Dispose();
-        }
-
-        if (_simulationTask is not null)
-        {
-            try
-            {
-                await _simulationTask;
-            }
-            catch (OperationCanceledException) { }
-        }
-
-        _timer?.Dispose();
-    }
-
     private enum PitchChoice
     {
         Flat,
@@ -275,5 +253,27 @@ public partial class CameraFollowExample : IAsyncDisposable
     {
         Ease,
         Jump,
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+
+        if (_cts is not null)
+        {
+            await _cts.CancelAsync();
+            _cts.Dispose();
+        }
+
+        if (_simulationTask is not null)
+        {
+            try
+            {
+                await _simulationTask;
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        _timer?.Dispose();
     }
 }

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/TrainTracking/TrainSampleState.cs
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/TrainTracking/TrainSampleState.cs
@@ -8,7 +8,7 @@ public sealed class TrainSampleState(
     string color,
     double speed,
     IReadOnlyList<Coordinate> waypoints
-    )
+)
 {
     public string Id { get; } = id;
 

--- a/src/Spillgebees.Blazor.Map.Docs/Samples/TrainTracking/TrainTrackingExample.razor.cs
+++ b/src/Spillgebees.Blazor.Map.Docs/Samples/TrainTracking/TrainTrackingExample.razor.cs
@@ -98,10 +98,7 @@ public partial class TrainTrackingExample : IAsyncDisposable
     }
 
     private static Dictionary<string, object?> BuildTrainProperties(TrainSampleState train) =>
-        new()
-        {
-            ["internationalPresence"] = TrainSampleSimulation.IsInternational(train) ? 1 : 0,
-        };
+        new() { ["internationalPresence"] = TrainSampleSimulation.IsInternational(train) ? 1 : 0 };
 
     private async Task HandleTrainClick(EntityEventArgs<TrainSampleState> interaction)
     {

--- a/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineFollowFunctionalTest.razor
+++ b/src/Spillgebees.Blazor.Map.IntegrationTests/Pages/EngineFollowFunctionalTest.razor
@@ -8,6 +8,7 @@
     <section style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1rem;">
         <button type="button" data-testid="start-follow" @onclick="StartFollow">Start follow</button>
         <button type="button" data-testid="start-follow-animated" @onclick="StartFollowAnimated">Start follow (animated)</button>
+        <button type="button" data-testid="start-follow-tracking-animated" @onclick="StartFollowTrackingAnimated">Start follow (tracking animated)</button>
         <button type="button" data-testid="start-follow-clear-missing" @onclick="StartFollowClearMissing">Start follow (clear if missing)</button>
         <button type="button" data-testid="start-follow-fixed-zoom" @onclick="StartFollowFixedZoom">Start follow (fixed zoom)</button>
         <button type="button" data-testid="clear-follow" @onclick="ClearFollow">Clear follow</button>
@@ -89,6 +90,18 @@
             "e1",
             Camera: new MapFollowCameraOptions(ZoomMode: MapFollowGestureMode.Anchored, Zoom: 14),
             Animation: new AnimationOptions(Duration: 1500)
+        );
+
+    private void StartFollowTrackingAnimated() =>
+        _follow = new MapFollowOptions(
+            "vehicles",
+            "e1",
+            Camera: new MapFollowCameraOptions(
+                ZoomMode: MapFollowGestureMode.Anchored,
+                Zoom: 14,
+                TrackingAnimation: new AnimationOptions(Duration: 1200, Easing: AnimationEasing.EaseInOut)
+            ),
+            Animation: new AnimationOptions(Duration: 0)
         );
 
     // An anchored zoom so the test can confirm the follow holds it: a later camera zoom should be pulled

--- a/src/Spillgebees.Blazor.Map.IntegrationTests/StressQuery.cs
+++ b/src/Spillgebees.Blazor.Map.IntegrationTests/StressQuery.cs
@@ -40,9 +40,7 @@ public sealed class StressQuery
         _values.TryGetValue(name, out var value) && int.TryParse(value, out var parsed) ? parsed : fallback;
 
     public bool GetBool(string name, bool fallback) =>
-        _values.TryGetValue(name, out var value)
-            ? value is "1" or "true" or "True" or "yes"
-            : fallback;
+        _values.TryGetValue(name, out var value) ? value is "1" or "true" or "True" or "yes" : fallback;
 
     public bool TryGetEnum<TEnum>(string name, out TEnum result)
         where TEnum : struct =>

--- a/src/Spillgebees.Blazor.Map.Tests/Components/SgbMapOverlayContentTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Components/SgbMapOverlayContentTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Components;
 
@@ -43,5 +44,62 @@ public class SgbMapOverlayContentTests : BunitContext
 
         // assert
         cut.FindAll(".sgb-map-overlay-root").Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Should_skip_control_sync_after_map_is_disposed()
+    {
+        // arrange
+        var map = CreateInitializedMap();
+        var host = (IMapControlHost)map;
+        await map.DisposeAsync();
+
+        // act
+        Func<Task> act = async () => await host.SyncControlsAsync();
+
+        // assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Should_complete_pending_control_sync_when_map_is_disposed()
+    {
+        // arrange
+        var map = CreateInitializedMap();
+        var host = (IMapControlHost)map;
+        var syncLock = GetControlSyncLock(map);
+        await syncLock.WaitAsync();
+        var syncTask = host.SyncControlsAsync().AsTask();
+
+        // act
+        Func<Task> act = async () =>
+        {
+            await map.DisposeAsync();
+            syncLock.Release();
+            await syncTask.WaitAsync(TimeSpan.FromSeconds(5));
+        };
+
+        // assert
+        syncTask.IsCompleted.Should().BeFalse();
+        await act.Should().NotThrowAsync();
+    }
+
+    private TestSgbMap CreateInitializedMap()
+    {
+        var map = new TestSgbMap();
+        typeof(SgbMap)
+            .GetProperty("_jsRuntime", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(map, JSInterop.JSRuntime);
+        map.Initialize();
+        return map;
+    }
+
+    private static SemaphoreSlim GetControlSyncLock(SgbMap map) =>
+        (SemaphoreSlim)
+            typeof(SgbMap).GetField("_controlSyncLock", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(map)!;
+
+    private sealed class TestSgbMap : SgbMap
+    {
+        public void Initialize() => OnInitialized();
     }
 }

--- a/src/Spillgebees.Blazor.Map.Tests/Components/SgbMapOverlayContentTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Components/SgbMapOverlayContentTests.cs
@@ -70,13 +70,15 @@ public class SgbMapOverlayContentTests : BunitContext
         var syncLock = GetControlSyncLock(map);
         await syncLock.WaitAsync();
         var syncTask = host.SyncControlsAsync().AsTask();
+        var disposeTask = map.DisposeAsync().AsTask();
 
         // act
         Func<Task> act = async () =>
         {
-            await map.DisposeAsync();
+            disposeTask.IsCompleted.Should().BeFalse();
             syncLock.Release();
             await syncTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
         };
 
         // assert

--- a/src/Spillgebees.Blazor.Map.Tests/Engine/CameraFollowOpSerializationTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Engine/CameraFollowOpSerializationTests.cs
@@ -51,6 +51,26 @@ public class CameraFollowOpSerializationTests
     }
 
     [Test]
+    public void Should_serialize_follow_camera_tracking_animation()
+    {
+        // arrange
+        var op = new CameraFollowOp(
+            "vehicles",
+            "bus-1",
+            new EngineFollowCamera(TrackingAnimation: new EngineAnimation(250, "linear"))
+        );
+
+        // act
+        var json = Serialize(op);
+
+        // assert
+        json.Should()
+            .Be(
+                """[{"op":"camera.follow","layerId":"vehicles","entityId":"bus-1","camera":{"zoomMode":"free","orientationMode":"free","bearingSource":"keepcurrent","trackingAnimation":{"durationMs":250,"easing":"linear"}}}]"""
+            );
+    }
+
+    [Test]
     public void Should_serialize_clear_follow_op()
     {
         // arrange & act

--- a/src/Spillgebees.Blazor.Map.Tests/Engine/EngineOpsSerializationTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Engine/EngineOpsSerializationTests.cs
@@ -155,7 +155,9 @@ public class EngineOpsSerializationTests
     public void Should_serialize_center_control_with_a_custom_icon()
     {
         // arrange
-        var setOp = new ControlSetOp(EngineControl.From(new CenterControlDefinition(Icon: "\u003Csvg data-center\u003E\u003C/svg\u003E")));
+        var setOp = new ControlSetOp(
+            EngineControl.From(new CenterControlDefinition(Icon: "\u003Csvg data-center\u003E\u003C/svg\u003E"))
+        );
 
         // act
         var json = Serialize(setOp);

--- a/src/Spillgebees.Blazor.Map.Tests/Engine/MapFollowCoordinatorTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Engine/MapFollowCoordinatorTests.cs
@@ -126,6 +126,32 @@ public class MapFollowCoordinatorTests
     }
 
     [Test]
+    public async Task Should_map_tracking_animation_inside_camera_options()
+    {
+        // arrange
+        static Task Act(MapFollowCoordinator c) =>
+            c.FollowAsync(
+                new MapFollowOptions(
+                    "vehicles",
+                    "bus-1",
+                    Camera: new MapFollowCameraOptions(
+                        TrackingAnimation: new AnimationOptions(Duration: 250, Easing: AnimationEasing.EaseInOut)
+                    ),
+                    Animation: new AnimationOptions(Duration: 600, Easing: AnimationEasing.Linear)
+                )
+            );
+
+        // act
+        var json = await CaptureFollowOps(Act);
+
+        // assert
+        json.Should()
+            .Be(
+                """[{"op":"camera.follow","layerId":"vehicles","entityId":"bus-1","camera":{"zoomMode":"free","orientationMode":"free","bearingSource":"keepcurrent","trackingAnimation":{"durationMs":250,"easing":"easeInOut"}},"animation":{"durationMs":600,"easing":"linear"}}]"""
+            );
+    }
+
+    [Test]
     public async Task Should_default_animation_easing_to_linear()
     {
         // arrange & act

--- a/src/Spillgebees.Blazor.Map.Tests/Engine/MotionFrameEncoderTests.cs
+++ b/src/Spillgebees.Blazor.Map.Tests/Engine/MotionFrameEncoderTests.cs
@@ -76,8 +76,6 @@ public class MotionFrameEncoderTests
         );
 
         // assert
-        base64
-            .Should()
-            .Be("AUJHUyoAAAABAAAABwAAAAMAAACeXinLEIcYQEp7gy9MzkhAAAC0QgAAoEA=");
+        base64.Should().Be("AUJHUyoAAAABAAAABwAAAAMAAACeXinLEIcYQEp7gy9MzkhAAAC0QgAAoEA=");
     }
 }

--- a/src/Spillgebees.Blazor.Map/Components/DisplayMapControl.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/DisplayMapControl.razor.cs
@@ -77,7 +77,9 @@ public partial class DisplayMapControl : ComponentBase, IDisposable
 
         if (_display is null)
         {
-            throw new InvalidOperationException("DisplayMapControl requires a cascading MapDisplayState (SgbMap Display parameter).");
+            throw new InvalidOperationException(
+                "DisplayMapControl requires a cascading MapDisplayState (SgbMap Display parameter)."
+            );
         }
 
         if (ReferenceEquals(_subscribedDisplay, _display))

--- a/src/Spillgebees.Blazor.Map/Components/GeolocateMapControl.cs
+++ b/src/Spillgebees.Blazor.Map/Components/GeolocateMapControl.cs
@@ -45,6 +45,5 @@ public sealed class GeolocateMapControl : ComponentBase, IAsyncDisposable
     /// <inheritdoc />
     public ValueTask DisposeAsync() => _registration.DisposeAsync(_registry);
 
-    private GeolocateControlDefinition BuildControl() =>
-        new(Id, Visible, Position, TrackUser, Order);
+    private GeolocateControlDefinition BuildControl() => new(Id, Visible, Position, TrackUser, Order);
 }

--- a/src/Spillgebees.Blazor.Map/Components/Layers/GeoJsonSource.cs
+++ b/src/Spillgebees.Blazor.Map/Components/Layers/GeoJsonSource.cs
@@ -99,7 +99,11 @@ public sealed class GeoJsonSource : ComponentBase, IAsyncDisposable, IEngineSour
             else
             {
                 Map.Channel.Queue(
-                    new SourceSetDataOp(Id, BuildDataNode(), animateMs is { } ms ? new EngineAnimation(ms, easing) : null)
+                    new SourceSetDataOp(
+                        Id,
+                        BuildDataNode(),
+                        animateMs is { } ms ? new EngineAnimation(ms, easing) : null
+                    )
                 );
             }
         }
@@ -133,7 +137,8 @@ public sealed class GeoJsonSource : ComponentBase, IAsyncDisposable, IEngineSour
         var spec = new JsonObject
         {
             ["type"] = "geojson",
-            ["data"] = BuildDataNode() ?? new JsonObject { ["type"] = "FeatureCollection", ["features"] = new JsonArray() },
+            ["data"] =
+                BuildDataNode() ?? new JsonObject { ["type"] = "FeatureCollection", ["features"] = new JsonArray() },
         };
         if (GenerateIds)
         {
@@ -168,7 +173,12 @@ public sealed class GeoJsonSource : ComponentBase, IAsyncDisposable, IEngineSour
 
         foreach (var definition in _clusterLayerDefinitions)
         {
-            Map.Channel.Queue(new LayerAddOp(ClusterLayerId(definition), EngineSpec.BuildClusterLayerSpec(ClusterLayerId(definition), Id, definition)));
+            Map.Channel.Queue(
+                new LayerAddOp(
+                    ClusterLayerId(definition),
+                    EngineSpec.BuildClusterLayerSpec(ClusterLayerId(definition), Id, definition)
+                )
+            );
         }
 
         if (Cluster is { ClickBehavior: ClusterClickBehavior.ZoomToDissolve })

--- a/src/Spillgebees.Blazor.Map/Components/Layers/TrackedEntityLayer.cs
+++ b/src/Spillgebees.Blazor.Map/Components/Layers/TrackedEntityLayer.cs
@@ -243,12 +243,12 @@ public sealed class TrackedEntityLayer<TItem> : ComponentBase, IAsyncDisposable
             ["hoverEnter"] = OnHoverEnter.HasDelegate,
             ["hoverLeave"] = OnHoverLeave.HasDelegate,
             ["symbol"] = BuildSymbolLayerSpec(),
-            ["clusterLayers"] = new JsonArray(
-                [.. _clusterLayerDefinitions.Select(definition => (JsonNode)BuildClusterLayerSpec(definition))]
-            ),
-            ["decorations"] = new JsonArray(
-                [.. _decorations.Select(decoration => (JsonNode)BuildDecorationLayerSpec(decoration))]
-            ),
+            ["clusterLayers"] = new JsonArray([
+                .. _clusterLayerDefinitions.Select(definition => (JsonNode)BuildClusterLayerSpec(definition)),
+            ]),
+            ["decorations"] = new JsonArray([
+                .. _decorations.Select(decoration => (JsonNode)BuildDecorationLayerSpec(decoration)),
+            ]),
         };
 
         return node.ToJsonString();
@@ -260,8 +260,7 @@ public sealed class TrackedEntityLayer<TItem> : ComponentBase, IAsyncDisposable
         || OnHoverEnter.HasDelegate
         || _decorations.Any(decoration => decoration.DisplayMode != EntityDecorationDisplayMode.Always);
 
-    private bool _interactionIsRelevant =>
-        _hoverIsRelevant || OnClick.HasDelegate || OnHoverLeave.HasDelegate;
+    private bool _interactionIsRelevant => _hoverIsRelevant || OnClick.HasDelegate || OnHoverLeave.HasDelegate;
 
     /// <summary>
     /// Every layer that participates in hover/click: the invisible hit area, the
@@ -487,10 +486,7 @@ public sealed class TrackedEntityLayer<TItem> : ComponentBase, IAsyncDisposable
             layout["icon-ignore-placement"] = true;
         }
 
-        var paint = new JsonObject
-        {
-            ["text-color"] = Expr("coalesce", Expr("get", "color"), "#0f172a"),
-        };
+        var paint = new JsonObject { ["text-color"] = Expr("coalesce", Expr("get", "color"), "#0f172a") };
 
         if (decoration.HaloColor is not null)
         {
@@ -527,7 +523,12 @@ public sealed class TrackedEntityLayer<TItem> : ComponentBase, IAsyncDisposable
         mode switch
         {
             EntityDecorationDisplayMode.OnHover => Expr("case", HoverState(), 1, 0),
-            EntityDecorationDisplayMode.OnHoverOrSelect => Expr("case", Expr("any", HoverState(), SelectedState()), 1, 0),
+            EntityDecorationDisplayMode.OnHoverOrSelect => Expr(
+                "case",
+                Expr("any", HoverState(), SelectedState()),
+                1,
+                0
+            ),
             _ => null,
         };
 
@@ -640,8 +641,7 @@ public sealed class TrackedEntityLayer<TItem> : ComponentBase, IAsyncDisposable
         );
     }
 
-    private static readonly IReadOnlyDictionary<string, object?> _emptyProperties =
-        new Dictionary<string, object?>();
+    private static readonly IReadOnlyDictionary<string, object?> _emptyProperties = new Dictionary<string, object?>();
 
     private JsonObject? BuildProps(TItem item)
     {

--- a/src/Spillgebees.Blazor.Map/Components/LegendMapControl.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/LegendMapControl.razor.cs
@@ -131,7 +131,8 @@ public partial class LegendMapControl : ComponentBase, IAsyncDisposable
 
     private bool GetItemOn(MapLegendItem item) => _displayBinder.GetItemOn(item);
 
-    private Task ToggleItemAsync(MapLegendItem item, ChangeEventArgs args) => _displayBinder.ToggleItemAsync(item, args);
+    private Task ToggleItemAsync(MapLegendItem item, ChangeEventArgs args) =>
+        _displayBinder.ToggleItemAsync(item, args);
 
     private MapLegendItemTemplateContext BuildTemplateContext(MapLegendItem item) =>
         _displayBinder.BuildTemplateContext(item);
@@ -190,9 +191,9 @@ public partial class LegendMapControl : ComponentBase, IAsyncDisposable
             return null;
         }
 
-        var sanitized = new string(
-            [.. cssClass.Where(character => char.IsLetterOrDigit(character) || character is '-' or '_' or ' ')]
-        );
+        var sanitized = new string([
+            .. cssClass.Where(character => char.IsLetterOrDigit(character) || character is '-' or '_' or ' '),
+        ]);
 
         return string.IsNullOrWhiteSpace(sanitized) ? null : sanitized.Trim();
     }

--- a/src/Spillgebees.Blazor.Map/Components/MapCircle.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapCircle.cs
@@ -63,6 +63,9 @@ public sealed class MapCircle : ComponentBase, IAsyncDisposable
     /// <summary>Removes the circle from the host map.</summary>
     public async ValueTask DisposeAsync() => await _registration.DisposeAsync();
 
-    private static ValueTask SetOverlayCirclesAsync(IMapFeatureHost map, string ownerId, IReadOnlyList<Circle> circles) =>
-        map.SetOverlayCirclesAsync(ownerId, circles);
+    private static ValueTask SetOverlayCirclesAsync(
+        IMapFeatureHost map,
+        string ownerId,
+        IReadOnlyList<Circle> circles
+    ) => map.SetOverlayCirclesAsync(ownerId, circles);
 }

--- a/src/Spillgebees.Blazor.Map/Components/MapControls.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapControls.cs
@@ -8,8 +8,7 @@ namespace Spillgebees.Blazor.Map;
 /// </summary>
 public sealed class MapControls : ComponentBase
 {
-    private MapSectionContext _sectionContext =>
-        field ??= new MapSectionContext(MapContentSectionKind.Controls);
+    private MapSectionContext _sectionContext => field ??= new MapSectionContext(MapContentSectionKind.Controls);
 
     [CascadingParameter]
     private MapRootContext? _rootContext { get; set; }

--- a/src/Spillgebees.Blazor.Map/Components/MapFeatures.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapFeatures.cs
@@ -8,8 +8,7 @@ namespace Spillgebees.Blazor.Map;
 /// </summary>
 public sealed class MapFeatures : ComponentBase
 {
-    private MapSectionContext _sectionContext =>
-        field ??= new MapSectionContext(MapContentSectionKind.Features);
+    private MapSectionContext _sectionContext => field ??= new MapSectionContext(MapContentSectionKind.Features);
 
     [CascadingParameter]
     private MapRootContext? _rootContext { get; set; }

--- a/src/Spillgebees.Blazor.Map/Components/MapMarker.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapMarker.cs
@@ -63,6 +63,9 @@ public sealed class MapMarker : ComponentBase, IAsyncDisposable
     /// <summary>Removes the marker from the host map.</summary>
     public async ValueTask DisposeAsync() => await _registration.DisposeAsync();
 
-    private static ValueTask SetOverlayMarkersAsync(IMapFeatureHost map, string ownerId, IReadOnlyList<Marker> markers) =>
-        map.SetOverlayMarkersAsync(ownerId, markers);
+    private static ValueTask SetOverlayMarkersAsync(
+        IMapFeatureHost map,
+        string ownerId,
+        IReadOnlyList<Marker> markers
+    ) => map.SetOverlayMarkersAsync(ownerId, markers);
 }

--- a/src/Spillgebees.Blazor.Map/Components/MapOverlay.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapOverlay.cs
@@ -129,7 +129,15 @@ public sealed class MapOverlay : ComponentBase, IAsyncDisposable
             Visible,
             Description,
             Symbol,
-            [.. _parts.Select(part => new MapOverlayPartItem(part.Id, part.Label ?? part.Id, part.Visible, part.Description, part.Symbol))]
+            [
+                .. _parts.Select(part => new MapOverlayPartItem(
+                    part.Id,
+                    part.Label ?? part.Id,
+                    part.Visible,
+                    part.Description,
+                    part.Symbol
+                )),
+            ]
         );
 
     internal void SetVisible(bool visible)

--- a/src/Spillgebees.Blazor.Map/Components/MapOverlays.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapOverlays.cs
@@ -8,8 +8,7 @@ namespace Spillgebees.Blazor.Map;
 /// </summary>
 public sealed class MapOverlays : ComponentBase
 {
-    private MapSectionContext _sectionContext =>
-        field ??= new MapSectionContext(MapContentSectionKind.Overlays);
+    private MapSectionContext _sectionContext => field ??= new MapSectionContext(MapContentSectionKind.Overlays);
 
     [CascadingParameter]
     private MapRootContext? _rootContext { get; set; }

--- a/src/Spillgebees.Blazor.Map/Components/MapPolyline.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapPolyline.cs
@@ -44,7 +44,13 @@ public sealed class MapPolyline : ComponentBase, IAsyncDisposable
     {
         var polyline = new Polyline(Id, GetCoordinateSnapshot(), Color, Width, Popup: Popup);
 
-        await _registration.RegisterAsync(_map, _sectionContext, nameof(MapPolyline), polyline, SetOverlayPolylinesAsync);
+        await _registration.RegisterAsync(
+            _map,
+            _sectionContext,
+            nameof(MapPolyline),
+            polyline,
+            SetOverlayPolylinesAsync
+        );
     }
 
     /// <summary>Removes the polyline from the host map.</summary>
@@ -66,6 +72,9 @@ public sealed class MapPolyline : ComponentBase, IAsyncDisposable
         return _cachedCoordinates;
     }
 
-    private static ValueTask SetOverlayPolylinesAsync(IMapFeatureHost map, string ownerId, IReadOnlyList<Polyline> polylines) =>
-        map.SetOverlayPolylinesAsync(ownerId, polylines);
+    private static ValueTask SetOverlayPolylinesAsync(
+        IMapFeatureHost map,
+        string ownerId,
+        IReadOnlyList<Polyline> polylines
+    ) => map.SetOverlayPolylinesAsync(ownerId, polylines);
 }

--- a/src/Spillgebees.Blazor.Map/Components/MapSources.cs
+++ b/src/Spillgebees.Blazor.Map/Components/MapSources.cs
@@ -8,8 +8,7 @@ namespace Spillgebees.Blazor.Map;
 /// </summary>
 public sealed class MapSources : ComponentBase
 {
-    private MapSectionContext _sectionContext =>
-        field ??= new MapSectionContext(MapContentSectionKind.Sources);
+    private MapSectionContext _sectionContext => field ??= new MapSectionContext(MapContentSectionKind.Sources);
 
     [CascadingParameter]
     private MapRootContext? _rootContext { get; set; }

--- a/src/Spillgebees.Blazor.Map/Components/NavigationMapControl.cs
+++ b/src/Spillgebees.Blazor.Map/Components/NavigationMapControl.cs
@@ -56,6 +56,5 @@ public sealed class NavigationMapControl : ComponentBase, IAsyncDisposable
     /// <inheritdoc />
     public ValueTask DisposeAsync() => _registration.DisposeAsync(_registry);
 
-    private NavigationControlDefinition BuildControl() =>
-        new(Id, Visible, Position, ShowCompass, ShowZoom, Order);
+    private NavigationControlDefinition BuildControl() => new(Id, Visible, Position, ShowCompass, ShowZoom, Order);
 }

--- a/src/Spillgebees.Blazor.Map/Components/OverlayMapControl.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/OverlayMapControl.razor.cs
@@ -208,9 +208,9 @@ public partial class OverlayMapControl : ComponentBase, IDisposable
             return null;
         }
 
-        var sanitized = new string(
-            [.. cssClass.Where(character => char.IsLetterOrDigit(character) || character is '-' or '_' or ' ')]
-        );
+        var sanitized = new string([
+            .. cssClass.Where(character => char.IsLetterOrDigit(character) || character is '-' or '_' or ' '),
+        ]);
 
         return string.IsNullOrWhiteSpace(sanitized) ? null : sanitized.Trim();
     }

--- a/src/Spillgebees.Blazor.Map/Components/SgbMap.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/SgbMap.razor.cs
@@ -212,6 +212,11 @@ public partial class SgbMap
     private readonly List<MapStyle> _overlayStyles = [];
     private readonly List<MapOverlay> _overlays = [];
     private readonly TaskCompletionSource<bool> _readyTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _controlSyncStateLock = new();
+    private readonly SemaphoreSlim _controlSyncLock = new(1, 1);
+    private bool _isDisposing;
+    private bool _controlSyncLockDisposed;
+    private int _controlSyncUsers;
 
     internal MapControlRegistryContext ControlRegistry { get; private set; } = null!;
 
@@ -454,7 +459,7 @@ public partial class SgbMap
                 IsReady = true;
                 _readyTcs.TrySetResult(true);
                 await Channel.MarkReadyAsync();
-                _controls.Sync();
+                await SyncControlsAsync();
                 // queue the initial fit after MarkReadyAsync so the feature data the
                 // fit resolves against has already landed JS-side
                 SyncFitBounds();
@@ -627,6 +632,7 @@ public partial class SgbMap
     /// <summary>Disposes the underlying map and releases JS interop resources.</summary>
     public async ValueTask DisposeAsync()
     {
+        MarkDisposing();
         _readyTcs.TrySetResult(false);
         _subscribedDisplay?.Changed -= HandleDisplayChanged;
 
@@ -638,6 +644,7 @@ public partial class SgbMap
         catch (ObjectDisposedException) { }
 
         Router.Dispose();
+        DisposeControlSyncLockIfIdle();
         GC.SuppressFinalize(this);
     }
 
@@ -654,10 +661,88 @@ public partial class SgbMap
 
     Task<bool> IMapControlHost.WhenReadyAsync() => IsReady ? Task.FromResult(true) : _readyTcs.Task;
 
-    ValueTask IMapControlHost.SyncControlsAsync()
+    ValueTask IMapControlHost.SyncControlsAsync() => SyncControlsAsync();
+
+    private async ValueTask SyncControlsAsync()
     {
-        _controls.Sync();
-        return ValueTask.CompletedTask;
+        if (!TryEnterControlSync())
+        {
+            return;
+        }
+
+        await _controlSyncLock.WaitAsync();
+        try
+        {
+            if (IsControlSyncDisposing())
+            {
+                return;
+            }
+
+            _controls.Sync();
+        }
+        finally
+        {
+            _controlSyncLock.Release();
+            ExitControlSync();
+        }
+    }
+
+    private void MarkDisposing()
+    {
+        lock (_controlSyncStateLock)
+        {
+            _isDisposing = true;
+        }
+    }
+
+    private bool IsControlSyncDisposing()
+    {
+        lock (_controlSyncStateLock)
+        {
+            return _isDisposing;
+        }
+    }
+
+    private bool TryEnterControlSync()
+    {
+        lock (_controlSyncStateLock)
+        {
+            if (_isDisposing || _controlSyncLockDisposed)
+            {
+                return false;
+            }
+
+            _controlSyncUsers++;
+            return true;
+        }
+    }
+
+    private void ExitControlSync()
+    {
+        lock (_controlSyncStateLock)
+        {
+            _controlSyncUsers--;
+        }
+
+        DisposeControlSyncLockIfIdle();
+    }
+
+    private void DisposeControlSyncLockIfIdle()
+    {
+        var shouldDispose = false;
+        lock (_controlSyncStateLock)
+        {
+            if (_isDisposing && _controlSyncUsers == 0 && !_controlSyncLockDisposed)
+            {
+                _controlSyncLockDisposed = true;
+                shouldDispose = true;
+            }
+        }
+
+        if (shouldDispose)
+        {
+            _controlSyncLock.Dispose();
+        }
     }
 
     ValueTask IMapControlHost.SetControlContentAsync(

--- a/src/Spillgebees.Blazor.Map/Components/SgbMap.razor.cs
+++ b/src/Spillgebees.Blazor.Map/Components/SgbMap.razor.cs
@@ -214,6 +214,7 @@ public partial class SgbMap
     private readonly TaskCompletionSource<bool> _readyTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object _controlSyncStateLock = new();
     private readonly SemaphoreSlim _controlSyncLock = new(1, 1);
+    private TaskCompletionSource? _controlSyncDrained;
     private bool _isDisposing;
     private bool _controlSyncLockDisposed;
     private int _controlSyncUsers;
@@ -629,25 +630,6 @@ public partial class SgbMap
         }
     }
 
-    /// <summary>Disposes the underlying map and releases JS interop resources.</summary>
-    public async ValueTask DisposeAsync()
-    {
-        MarkDisposing();
-        _readyTcs.TrySetResult(false);
-        _subscribedDisplay?.Changed -= HandleDisplayChanged;
-
-        try
-        {
-            await MapEngineJs.DisposeMapAsync(_jsRuntime, _container);
-        }
-        catch (JSDisconnectedException) { }
-        catch (ObjectDisposedException) { }
-
-        Router.Dispose();
-        DisposeControlSyncLockIfIdle();
-        GC.SuppressFinalize(this);
-    }
-
     // --- host interface forwarding (the shared component family binds to these) ---
 
     bool IMapControlHost.RegisterControl(string ownerId, MapControlDefinition control) =>
@@ -684,64 +666,6 @@ public partial class SgbMap
         {
             _controlSyncLock.Release();
             ExitControlSync();
-        }
-    }
-
-    private void MarkDisposing()
-    {
-        lock (_controlSyncStateLock)
-        {
-            _isDisposing = true;
-        }
-    }
-
-    private bool IsControlSyncDisposing()
-    {
-        lock (_controlSyncStateLock)
-        {
-            return _isDisposing;
-        }
-    }
-
-    private bool TryEnterControlSync()
-    {
-        lock (_controlSyncStateLock)
-        {
-            if (_isDisposing || _controlSyncLockDisposed)
-            {
-                return false;
-            }
-
-            _controlSyncUsers++;
-            return true;
-        }
-    }
-
-    private void ExitControlSync()
-    {
-        lock (_controlSyncStateLock)
-        {
-            _controlSyncUsers--;
-        }
-
-        DisposeControlSyncLockIfIdle();
-    }
-
-    private void DisposeControlSyncLockIfIdle()
-    {
-        var shouldDispose = false;
-        lock (_controlSyncStateLock)
-        {
-            if (_isDisposing && _controlSyncUsers == 0 && !_controlSyncLockDisposed)
-            {
-                _controlSyncLockDisposed = true;
-                shouldDispose = true;
-            }
-        }
-
-        if (shouldDispose)
-        {
-            _controlSyncLock.Dispose();
         }
     }
 
@@ -833,4 +757,106 @@ public partial class SgbMap
 
     void IMapOverlayHost.SetOverlayPartVisible(string overlayId, string partId, bool visible) =>
         _ = SetOverlayPartVisibleAsync(overlayId, partId, visible);
+
+    private void MarkDisposing()
+    {
+        lock (_controlSyncStateLock)
+        {
+            _isDisposing = true;
+            if (_controlSyncUsers > 0)
+            {
+                _controlSyncDrained ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+    }
+
+    private bool IsControlSyncDisposing()
+    {
+        lock (_controlSyncStateLock)
+        {
+            return _isDisposing;
+        }
+    }
+
+    private bool TryEnterControlSync()
+    {
+        lock (_controlSyncStateLock)
+        {
+            if (_isDisposing || _controlSyncLockDisposed)
+            {
+                return false;
+            }
+
+            _controlSyncUsers++;
+            return true;
+        }
+    }
+
+    private void ExitControlSync()
+    {
+        TaskCompletionSource? drained = null;
+        lock (_controlSyncStateLock)
+        {
+            _controlSyncUsers--;
+            if (_isDisposing && _controlSyncUsers == 0)
+            {
+                drained = _controlSyncDrained;
+            }
+        }
+
+        drained?.TrySetResult();
+        DisposeControlSyncLockIfIdle();
+    }
+
+    private void DisposeControlSyncLockIfIdle()
+    {
+        var shouldDispose = false;
+        lock (_controlSyncStateLock)
+        {
+            if (_isDisposing && _controlSyncUsers == 0 && !_controlSyncLockDisposed)
+            {
+                _controlSyncLockDisposed = true;
+                shouldDispose = true;
+            }
+        }
+
+        if (shouldDispose)
+        {
+            _controlSyncLock.Dispose();
+        }
+    }
+
+    private Task DrainControlSyncsAsync()
+    {
+        lock (_controlSyncStateLock)
+        {
+            if (_controlSyncUsers == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            _controlSyncDrained ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return _controlSyncDrained.Task;
+        }
+    }
+
+    /// <summary>Disposes the underlying map and releases JS interop resources.</summary>
+    public async ValueTask DisposeAsync()
+    {
+        MarkDisposing();
+        await DrainControlSyncsAsync();
+        _readyTcs.TrySetResult(false);
+        _subscribedDisplay?.Changed -= HandleDisplayChanged;
+
+        try
+        {
+            await MapEngineJs.DisposeMapAsync(_jsRuntime, _container);
+        }
+        catch (JSDisconnectedException) { }
+        catch (ObjectDisposedException) { }
+
+        Router.Dispose();
+        DisposeControlSyncLockIfIdle();
+        GC.SuppressFinalize(this);
+    }
 }

--- a/src/Spillgebees.Blazor.Map/Engine/EngineJson.cs
+++ b/src/Spillgebees.Blazor.Map/Engine/EngineJson.cs
@@ -11,7 +11,8 @@ namespace Spillgebees.Blazor.Map.Engine;
 /// </summary>
 internal static class EngineJson
 {
-    public static JsonNode? ToNode<T>(StyleValue<T>? style) => style is { } value ? ToNode(value.ToSerializable()) : null;
+    public static JsonNode? ToNode<T>(StyleValue<T>? style) =>
+        style is { } value ? ToNode(value.ToSerializable()) : null;
 
     public static JsonNode? ToNode(object? value) =>
         value switch

--- a/src/Spillgebees.Blazor.Map/Engine/EngineOps.cs
+++ b/src/Spillgebees.Blazor.Map/Engine/EngineOps.cs
@@ -320,7 +320,8 @@ internal sealed record EngineFollowCamera(
     double? Pitch = null,
     string BearingSource = "keepcurrent",
     double? Bearing = null,
-    PixelPoint? Offset = null
+    PixelPoint? Offset = null,
+    EngineAnimation? TrackingAnimation = null
 );
 
 internal sealed record EngineFollowInteraction(bool ClearOnUserPan = true, bool ClearWhenFeatureMissing = false);

--- a/src/Spillgebees.Blazor.Map/Engine/EngineStyleJson.cs
+++ b/src/Spillgebees.Blazor.Map/Engine/EngineStyleJson.cs
@@ -28,9 +28,7 @@ internal static class EngineStyleJson
             onError(new InvalidOperationException("Overlay styles require a typed base style (Style or Styles)."));
         }
 
-        var effectiveStyles = baseStyles is null
-            ? null
-            : (IReadOnlyList<MapStyle>)[.. baseStyles, .. overlayStyles];
+        var effectiveStyles = baseStyles is null ? null : (IReadOnlyList<MapStyle>)[.. baseStyles, .. overlayStyles];
         if (effectiveStyles is { Count: > 0 })
         {
             var array = new JsonArray();

--- a/src/Spillgebees.Blazor.Map/Engine/MapEngineChannel.cs
+++ b/src/Spillgebees.Blazor.Map/Engine/MapEngineChannel.cs
@@ -16,7 +16,8 @@ internal sealed class MapEngineChannel(IJSRuntime jsRuntime)
 {
     private readonly List<EngineOp> _pendingOps = [];
     private readonly Dictionary<string, byte[]> _pendingMotion = [];
-    private readonly Dictionary<string, (string DataJson, int? AnimateMs, string? AnimateEasing)> _pendingSourceData = [];
+    private readonly Dictionary<string, (string DataJson, int? AnimateMs, string? AnimateEasing)> _pendingSourceData =
+    [];
     private ElementReference _container;
     private bool _isReady;
     private bool _flushScheduled;

--- a/src/Spillgebees.Blazor.Map/Engine/MapFollowCoordinator.cs
+++ b/src/Spillgebees.Blazor.Map/Engine/MapFollowCoordinator.cs
@@ -26,7 +26,8 @@ internal sealed class MapFollowCoordinator(MapEngineChannel channel)
                 camera.Pitch,
                 ToWire(camera.BearingSource),
                 camera.Bearing,
-                camera.Offset
+                camera.Offset,
+                ToEngine(camera.TrackingAnimation)
             );
 
     private static string ToWire(MapFollowGestureMode mode) =>

--- a/src/Spillgebees.Blazor.Map/Models/Controls/MapControlOptions.cs
+++ b/src/Spillgebees.Blazor.Map/Models/Controls/MapControlOptions.cs
@@ -1,7 +1,7 @@
-
 using Microsoft.AspNetCore.Components;
 
 namespace Spillgebees.Blazor.Map;
+
 /// <summary>
 /// Shared placement options for map controls.
 /// </summary>

--- a/src/Spillgebees.Blazor.Map/Models/Display/MapDisplayState.cs
+++ b/src/Spillgebees.Blazor.Map/Models/Display/MapDisplayState.cs
@@ -23,8 +23,8 @@ public sealed class MapDisplayState
     [AllowNull]
     public IReadOnlyList<MapDisplayItem> Items
     {
-        get =>
-        field ??= Array.AsReadOnly(_itemIds.Select(id => _items[id]).ToArray()); private set;
+        get => field ??= Array.AsReadOnly(_itemIds.Select(id => _items[id]).ToArray());
+        private set;
     }
 
     /// <summary>Returns whether an item exists.</summary>

--- a/src/Spillgebees.Blazor.Map/Models/Follow/MapFollowCameraOptions.cs
+++ b/src/Spillgebees.Blazor.Map/Models/Follow/MapFollowCameraOptions.cs
@@ -16,6 +16,7 @@ namespace Spillgebees.Blazor.Map;
 /// <param name="BearingSource">Where the held bearing comes from while <paramref name="OrientationMode"/> holds a target; ignored otherwise.</param>
 /// <param name="Bearing">Bearing to hold when <paramref name="BearingSource"/> is <see cref="MapFollowBearingSource.Fixed"/>; ignored otherwise.</param>
 /// <param name="Offset">Pixel offset of the followed entity from the screen centre. Null centres exactly.</param>
+/// <param name="TrackingAnimation">Animation for post-engage tracking moves after discrete or jumped updates. Null keeps tracking instant.</param>
 public sealed record MapFollowCameraOptions(
     MapFollowGestureMode ZoomMode = MapFollowGestureMode.Free,
     double? Zoom = null,
@@ -23,5 +24,6 @@ public sealed record MapFollowCameraOptions(
     double? Pitch = null,
     MapFollowBearingSource BearingSource = MapFollowBearingSource.KeepCurrent,
     double? Bearing = null,
-    PixelPoint? Offset = null
+    PixelPoint? Offset = null,
+    AnimationOptions? TrackingAnimation = null
 );

--- a/src/Spillgebees.Blazor.Map/Models/Follow/MapFollowOptions.cs
+++ b/src/Spillgebees.Blazor.Map/Models/Follow/MapFollowOptions.cs
@@ -13,10 +13,10 @@ namespace Spillgebees.Blazor.Map;
 /// </param>
 /// <param name="Camera">Camera behaviour while following. <c>null</c> preserves current zoom, pitch, and bearing.</param>
 /// <param name="Animation">
-/// Animation for discrete camera moves (engage and non-animated updates). When <c>null</c>, defaults to a
-/// 500ms ease-in-out engage; when set, only <see cref="AnimationOptions.Duration"/> and
-/// <see cref="AnimationOptions.Easing"/> apply. While the entity is interpolating, the camera rides
-/// the motion frames and this is unused.
+/// Initial animation when the follow engages. When <c>null</c>, defaults to a 500ms ease-in-out
+/// engage; when set, only <see cref="AnimationOptions.Duration"/> and
+/// <see cref="AnimationOptions.Easing"/> apply. Post-engage tracking uses
+/// <see cref="MapFollowCameraOptions.TrackingAnimation"/>.
 /// </param>
 /// <param name="Interaction">Which user interactions clear the follow. <c>null</c> uses the defaults.</param>
 public sealed record MapFollowOptions(

--- a/src/Spillgebees.Blazor.Map/Models/Legends/MapLegendItemTemplateContext.cs
+++ b/src/Spillgebees.Blazor.Map/Models/Legends/MapLegendItemTemplateContext.cs
@@ -1,4 +1,5 @@
 namespace Spillgebees.Blazor.Map;
+
 /// <summary>
 /// Default legend item template context.
 /// </summary>

--- a/src/Spillgebees.Blazor.Map/PublicAPI.Shipped.txt
+++ b/src/Spillgebees.Blazor.Map/PublicAPI.Shipped.txt
@@ -633,13 +633,15 @@ Spillgebees.Blazor.Map.MapFollowCameraOptions.Bearing.get -> double?
 Spillgebees.Blazor.Map.MapFollowCameraOptions.Bearing.init -> void
 Spillgebees.Blazor.Map.MapFollowCameraOptions.BearingSource.get -> Spillgebees.Blazor.Map.MapFollowBearingSource
 Spillgebees.Blazor.Map.MapFollowCameraOptions.BearingSource.init -> void
-Spillgebees.Blazor.Map.MapFollowCameraOptions.MapFollowCameraOptions(Spillgebees.Blazor.Map.MapFollowGestureMode ZoomMode = Spillgebees.Blazor.Map.MapFollowGestureMode.Free, double? Zoom = null, Spillgebees.Blazor.Map.MapFollowGestureMode OrientationMode = Spillgebees.Blazor.Map.MapFollowGestureMode.Free, double? Pitch = null, Spillgebees.Blazor.Map.MapFollowBearingSource BearingSource = Spillgebees.Blazor.Map.MapFollowBearingSource.KeepCurrent, double? Bearing = null, Spillgebees.Blazor.Map.PixelPoint? Offset = null) -> void
+Spillgebees.Blazor.Map.MapFollowCameraOptions.MapFollowCameraOptions(Spillgebees.Blazor.Map.MapFollowGestureMode ZoomMode = Spillgebees.Blazor.Map.MapFollowGestureMode.Free, double? Zoom = null, Spillgebees.Blazor.Map.MapFollowGestureMode OrientationMode = Spillgebees.Blazor.Map.MapFollowGestureMode.Free, double? Pitch = null, Spillgebees.Blazor.Map.MapFollowBearingSource BearingSource = Spillgebees.Blazor.Map.MapFollowBearingSource.KeepCurrent, double? Bearing = null, Spillgebees.Blazor.Map.PixelPoint? Offset = null, Spillgebees.Blazor.Map.AnimationOptions? TrackingAnimation = null) -> void
 Spillgebees.Blazor.Map.MapFollowCameraOptions.Offset.get -> Spillgebees.Blazor.Map.PixelPoint?
 Spillgebees.Blazor.Map.MapFollowCameraOptions.Offset.init -> void
 Spillgebees.Blazor.Map.MapFollowCameraOptions.OrientationMode.get -> Spillgebees.Blazor.Map.MapFollowGestureMode
 Spillgebees.Blazor.Map.MapFollowCameraOptions.OrientationMode.init -> void
 Spillgebees.Blazor.Map.MapFollowCameraOptions.Pitch.get -> double?
 Spillgebees.Blazor.Map.MapFollowCameraOptions.Pitch.init -> void
+Spillgebees.Blazor.Map.MapFollowCameraOptions.TrackingAnimation.get -> Spillgebees.Blazor.Map.AnimationOptions?
+Spillgebees.Blazor.Map.MapFollowCameraOptions.TrackingAnimation.init -> void
 Spillgebees.Blazor.Map.MapFollowCameraOptions.Zoom.get -> double?
 Spillgebees.Blazor.Map.MapFollowCameraOptions.Zoom.init -> void
 Spillgebees.Blazor.Map.MapFollowCameraOptions.ZoomMode.get -> Spillgebees.Blazor.Map.MapFollowGestureMode


### PR DESCRIPTION
Allow setting a tracking animation for the camera follow mode on top of the engage animation. This allows for smooth camera tracking when entities jump from position to position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable camera follow tracking animation with Instant, Ease-in-out, and Linear options.
  * Camera follow now supports distinct animation for initial engage vs post-engage tracking updates.
  * Updated camera-follow and train-tracking samples with new tracking and motion controls.

* **Bug Fixes**
  * Fixed tracking animation timing so continuous re-centering no longer restarts configured tracking on every frame.
  * Ensured “jumped” updates preserve the configured tracking animation (including correct Linear easing override).

* **Tests**
  * Added integration and unit coverage for tracking animation behavior and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->