### PR TITLE
🐛  fix control ordering when comparing different corners concurrently

### DIFF
--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.test.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.test.ts
@@ -95,6 +95,27 @@ describe("engine controls controller", () => {
     expect(controller.ids()).toEqual(["a", "b"]);
   });
 
+  it("orders same-position controls when another position is interleaved", () => {
+    const { controller } = createHarness();
+    controller.set(navigation({ controlId: "last", order: 500 }));
+    controller.set(center());
+    controller.set(navigation({ controlId: "first", order: 100 }));
+
+    expect(controller.ids()).toEqual(["first", "last", "center"]);
+  });
+
+  it("preserves same-position order when delayed custom content is attached", () => {
+    const { controller, contentFor } = createHarness();
+    contentFor("content-1");
+    controller.set({ kind: "content", controlId: "content-1", visible: true, position: "top-right", order: 500 });
+    controller.set(center());
+    controller.set(navigation());
+
+    controller.setContent("content-1");
+
+    expect(controller.ids()).toEqual(["nav", "content-1", "center"]);
+  });
+
   it("skips invisible controls and removes dropped ones", () => {
     const { controller, map } = createHarness();
     controller.set(navigation());

--- a/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.ts
+++ b/src/Spillgebees.Blazor.Map.Assets/src/engine/controls.ts
@@ -167,7 +167,10 @@ export function createControlsController(
     }
     attached.length = 0;
 
-    const ordered: { id: string; control: IControl; position: string; order: number; declarationOrder: number }[] = [];
+    const groups = new Map<
+      string,
+      { id: string; control: IControl; position: string; order: number; declarationOrder: number }[]
+    >();
     let declarationOrder = 0;
     for (const definition of definitions.values()) {
       const index = declarationOrder++;
@@ -180,35 +183,41 @@ export function createControlsController(
         continue;
       }
 
-      ordered.push({
+      const entry = {
         id: definition.controlId,
         control,
         position: definition.position,
         order: definition.order,
         declarationOrder: index,
-      });
+      };
+      const group = groups.get(definition.position);
+      if (group) {
+        group.push(entry);
+      } else {
+        groups.set(definition.position, [entry]);
+      }
     }
 
-    ordered.sort((left, right) => {
-      if (left.position !== right.position) {
-        // cross-position ordering is irrelevant; stable sort preserves declaration order across buckets
-        return 0;
+    // Order is scoped to one MapLibre corner. Keeping position buckets separate
+    // ensures controls in the same corner are always compared, even when their
+    // definitions are interleaved with controls from other corners.
+    for (const group of groups.values()) {
+      group.sort((left, right) => {
+        if (left.order !== right.order) {
+          return left.order - right.order;
+        }
+
+        if (left.declarationOrder !== right.declarationOrder) {
+          return left.declarationOrder - right.declarationOrder;
+        }
+
+        return left.id.localeCompare(right.id);
+      });
+
+      for (const entry of group) {
+        map.addControl(entry.control, entry.position as never);
+        attached.push({ id: entry.id, control: entry.control });
       }
-
-      if (left.order !== right.order) {
-        return left.order - right.order;
-      }
-
-      if (left.declarationOrder !== right.declarationOrder) {
-        return left.declarationOrder - right.declarationOrder;
-      }
-
-      return left.id.localeCompare(right.id);
-    });
-
-    for (const entry of ordered) {
-      map.addControl(entry.control, entry.position as never);
-      attached.push({ id: entry.id, control: entry.control });
     }
   }
 


### PR DESCRIPTION
Fixes an issue where occasionally (we only managed to reproduce it on an iPad) the ordering of controls was incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map control ordering so controls in the same position remain deterministic.
  * Preserved established control order when custom content is added after initial setup.

* **Tests**
  * Added coverage for controls interleaved across positions and content attached later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->